### PR TITLE
Show Infobox for iOS 13.6 users with language German (de)

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -97,7 +97,7 @@ public class DPPPTConfigController {
 	private void setInfoTextForiOS136DE(ConfigResponse configResponse) {
 		InfoBox infoBoxDe = new InfoBox();
 		infoBoxDe.setMsg(
-				"Neu erscheint auf iOS 13.6 von Apple wöchentlich eine Benachrichtigung: «Dein Gerät hat 0 mögliche Begegnungen identifiziert.»."
+				"Neu erscheint auf iOS 13.6 von Apple wöchentlich eine Benachrichtigung: «Dein Gerät hat 0 mögliche Begegnungen identifiziert.»"
 				+ " Dies ist ein Übersetzungsfehler. Es bedeutet, dass es null positiv getestete Kontakte gab."
 				+ " Die App funktioniert weiterhin und zeichnet alle Kontakte auf.");
 		infoBoxDe.setTitle("Hinweis");

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -97,9 +97,9 @@ public class DPPPTConfigController {
 	private void setInfoTextForiOS136DE(ConfigResponse configResponse) {
 		InfoBox infoBoxDe = new InfoBox();
 		infoBoxDe.setMsg(
-				"Auf iOS 13.6 wird neu von Apple wöchentlich eine Benachrichtigung erscheinen, dass SwissCovid aktiv ist "
-						+ "und “0 mögliche Begegnungen identifiziert” hat. Dies ist ein Übersetzungsfehler, gemeint sind 0 Kontakte "
-						+ "zu positiv getesteten Personen. Die App funktioniert weiterhin und zeichnet alle Kontakte auf.");
+				"Neu erscheint auf iOS 13.6 von Apple wöchentlich eine Benachrichtigung: «Dein Gerät hat 0 mögliche Begegnungen identifiziert.»."
+				+ " Dies ist ein Übersetzungsfehler. Es bedeutet, dass es null positiv getestete Kontakte gab."
+				+ " Die App funktioniert weiterhin und zeichnet alle Kontakte auf.");
 		infoBoxDe.setTitle("Hinweis");
 		infoBoxDe.setUrl(
 				"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/faq-kontakte-downloads/haeufig-gestellte-fragen.html?faq-url=/de/categories/swisscovid-app");

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBoxCollection.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBoxCollection.java
@@ -10,104 +10,109 @@
 
 package org.dpppt.switzerland.backend.sdk.config.ws.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(value = Include.NON_NULL)
 public class InfoBoxCollection {
-    private InfoBox deInfoBox;
-    private InfoBox frInfoBox;
-    private InfoBox itInfoBox;
-    private InfoBox enInfoBox;
-    private InfoBox ptInfoBox;
-    private InfoBox esInfoBox;
-    private InfoBox sqInfoBox;
-    private InfoBox bsInfoBox;
-    private InfoBox hrInfoBox;
-    private InfoBox srInfoBox;
-    private InfoBox rmInfoBox;
+	
+	private InfoBox deInfoBox;
+	private InfoBox frInfoBox;
+	private InfoBox itInfoBox;
+	private InfoBox enInfoBox;
+	private InfoBox ptInfoBox;
+	private InfoBox esInfoBox;
+	private InfoBox sqInfoBox;
+	private InfoBox bsInfoBox;
+	private InfoBox hrInfoBox;
+	private InfoBox srInfoBox;
+	private InfoBox rmInfoBox;
 
-    public InfoBox getPtInfoBox() {
-        return this.ptInfoBox;
-    }
+	public InfoBox getPtInfoBox() {
+		return this.ptInfoBox;
+	}
 
-    public void setPtInfoBox(InfoBox ptInfoBox) {
-        this.ptInfoBox = ptInfoBox;
-    }
+	public void setPtInfoBox(InfoBox ptInfoBox) {
+		this.ptInfoBox = ptInfoBox;
+	}
 
-    public InfoBox getEsInfoBox() {
-        return this.esInfoBox;
-    }
+	public InfoBox getEsInfoBox() {
+		return this.esInfoBox;
+	}
 
-    public void setEsInfoBox(InfoBox esInfoBox) {
-        this.esInfoBox = esInfoBox;
-    }
+	public void setEsInfoBox(InfoBox esInfoBox) {
+		this.esInfoBox = esInfoBox;
+	}
 
-    public InfoBox getSqInfoBox() {
-        return this.sqInfoBox;
-    }
+	public InfoBox getSqInfoBox() {
+		return this.sqInfoBox;
+	}
 
-    public void setSqInfoBox(InfoBox sqInfoBox) {
-        this.sqInfoBox = sqInfoBox;
-    }
+	public void setSqInfoBox(InfoBox sqInfoBox) {
+		this.sqInfoBox = sqInfoBox;
+	}
 
-    public InfoBox getBsInfoBox() {
-        return this.bsInfoBox;
-    }
+	public InfoBox getBsInfoBox() {
+		return this.bsInfoBox;
+	}
 
-    public void setBsInfoBox(InfoBox bsInfoBox) {
-        this.bsInfoBox = bsInfoBox;
-    }
+	public void setBsInfoBox(InfoBox bsInfoBox) {
+		this.bsInfoBox = bsInfoBox;
+	}
 
-    public InfoBox getHrInfoBox() {
-        return this.hrInfoBox;
-    }
+	public InfoBox getHrInfoBox() {
+		return this.hrInfoBox;
+	}
 
-    public void setHrInfoBox(InfoBox hrInfoBox) {
-        this.hrInfoBox = hrInfoBox;
-    }
+	public void setHrInfoBox(InfoBox hrInfoBox) {
+		this.hrInfoBox = hrInfoBox;
+	}
 
-    public InfoBox getSrInfoBox() {
-        return this.srInfoBox;
-    }
+	public InfoBox getSrInfoBox() {
+		return this.srInfoBox;
+	}
 
-    public void setSrInfoBox(InfoBox srInfoBox) {
-        this.srInfoBox = srInfoBox;
-    }
+	public void setSrInfoBox(InfoBox srInfoBox) {
+		this.srInfoBox = srInfoBox;
+	}
 
-    public InfoBox getRmInfoBox() {
-        return this.rmInfoBox;
-    }
+	public InfoBox getRmInfoBox() {
+		return this.rmInfoBox;
+	}
 
-    public void setRmInfoBox(InfoBox rmInfoBox) {
-        this.rmInfoBox = rmInfoBox;
-    }
+	public void setRmInfoBox(InfoBox rmInfoBox) {
+		this.rmInfoBox = rmInfoBox;
+	}
 
-    public InfoBox getDeInfoBox() {
-        return deInfoBox;
-    }
+	public InfoBox getDeInfoBox() {
+		return deInfoBox;
+	}
 
-    public InfoBox getEnInfoBox() {
-        return enInfoBox;
-    }
+	public InfoBox getEnInfoBox() {
+		return enInfoBox;
+	}
 
-    public void setEnInfoBox(InfoBox enInfoBox) {
-        this.enInfoBox = enInfoBox;
-    }
+	public void setEnInfoBox(InfoBox enInfoBox) {
+		this.enInfoBox = enInfoBox;
+	}
 
-    public InfoBox getItInfoBox() {
-        return itInfoBox;
-    }
+	public InfoBox getItInfoBox() {
+		return itInfoBox;
+	}
 
-    public void setItInfoBox(InfoBox itInfoBox) {
-        this.itInfoBox = itInfoBox;
-    }
+	public void setItInfoBox(InfoBox itInfoBox) {
+		this.itInfoBox = itInfoBox;
+	}
 
-    public InfoBox getFrInfoBox() {
-        return frInfoBox;
-    }
+	public InfoBox getFrInfoBox() {
+		return frInfoBox;
+	}
 
-    public void setFrInfoBox(InfoBox frInfoBox) {
-        this.frInfoBox = frInfoBox;
-    }
+	public void setFrInfoBox(InfoBox frInfoBox) {
+		this.frInfoBox = frInfoBox;
+	}
 
-    public void setDeInfoBox(InfoBox deInfoBox) {
-        this.deInfoBox = deInfoBox;
-    }
+	public void setDeInfoBox(InfoBox deInfoBox) {
+		this.deInfoBox = deInfoBox;
+	}
 }


### PR DESCRIPTION
Users running on iOS 13.6 with app language German, will start to see a message explaining the misleading translation of Apple in their newly introduced "Weekly Update" notification (https://github.com/DP-3T/dp3t-app-ios-ch/issues/228)

<img width="375" alt="Unknown-1" src="https://user-images.githubusercontent.com/35527968/88198320-dfedcc00-cc43-11ea-9f1f-b6029ac632be.png">
