### PR TITLE
Feature/dismissible flag

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -104,7 +104,7 @@ public class DPPPTConfigController {
 		infoBoxDe.setUrl(
 				"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/faq-kontakte-downloads/haeufig-gestellte-fragen.html?faq-url=/de/categories/swisscovid-app");
 		infoBoxDe.setUrlTitle("Weitere Informationen");
-		infoBoxDe.setDismissible(true);
+		infoBoxDe.setIsDismissible(true);
 		InfoBoxCollection infoBoxCollection = new InfoBoxCollection();
 		infoBoxCollection.setDeInfoBox(infoBoxDe);
 		configResponse.setInfoBox(infoBoxCollection);

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -104,6 +104,7 @@ public class DPPPTConfigController {
 		infoBoxDe.setUrl(
 				"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/faq-kontakte-downloads/haeufig-gestellte-fragen.html?faq-url=/de/categories/swisscovid-app");
 		infoBoxDe.setUrlTitle("Weitere Informationen");
+		infoBoxDe.setDismissible(true);
 		InfoBoxCollection infoBoxCollection = new InfoBoxCollection();
 		infoBoxCollection.setDeInfoBox(infoBoxDe);
 		configResponse.setInfoBox(infoBoxCollection);

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequestMapping("/v1")
 public class DPPPTConfigController {
 	
-	private static final Version CURRENT_RELEASE_VERSIONS = new Version("1.0.7");
+	private static final Version CURRENT_RELEASE_VERSION = new Version("1.0.7");
 	private static final String IOS_VERSION_DE_WEEKLY_NOTIFCATION_INFO = "ios13.6";
 	private static final List<String> TESTFLIGHT_VERSIONS = List.of("ios-200619.2333.175", 
 			   "ios-200612.2347.141",
@@ -67,7 +67,7 @@ public class DPPPTConfigController {
 
 		// update message for various old builds
 		var appVersion = new Version(appversion);
-		if (!appVersion.isValid() || appVersion.isSmallerVersionThan(CURRENT_RELEASE_VERSIONS)) {
+		if (!appVersion.isValid() || appVersion.isSmallerVersionThan(CURRENT_RELEASE_VERSION)) {
 			config = generalUpdateRelease1(appVersion.isIOS());
 		}
 

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequestMapping("/v1")
 public class DPPPTConfigController {
 	
-	private static final Version INITIAL_RELEASE_VERSIONS = new Version("1.0.5");
+	private static final Version CURRENT_RELEASE_VERSIONS = new Version("1.0.7");
 	private static final String IOS_VERSION_DE_WEEKLY_NOTIFCATION_INFO = "ios13.6";
 	private static final List<String> TESTFLIGHT_VERSIONS = List.of("ios-200619.2333.175", 
 			   "ios-200612.2347.141",
@@ -67,7 +67,7 @@ public class DPPPTConfigController {
 
 		// update message for various old builds
 		var appVersion = new Version(appversion);
-		if (!appVersion.isValid() || appVersion.isSmallerVersionThan(INITIAL_RELEASE_VERSIONS)) {
+		if (!appVersion.isValid() || appVersion.isSmallerVersionThan(CURRENT_RELEASE_VERSIONS)) {
 			config = generalUpdateRelease1(appVersion.isIOS());
 		}
 

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBox.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBox.java
@@ -10,58 +10,62 @@
 
 package org.dpppt.switzerland.backend.sdk.config.ws.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * @author bachmann created on 28.04.20
  **/
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class InfoBox {
 
-    private String title;
-    private String msg;
-    private String url;
-    private String urlTitle;
-    private boolean isDismissible = false;
+	private String title;
+	private String msg;
+	private String url;
+	private String urlTitle;
+	private boolean isDismissible = false;
 
-    public String getInfoId() {
-        return Integer.toString(getTitle().hashCode() + getMsg().hashCode() + getUrl().hashCode() + getUrlTitle().hashCode());
-    }
+	public String getInfoId() {
+		return Integer
+				.toString(getTitle().hashCode() + getMsg().hashCode() + getUrl().hashCode() + getUrlTitle().hashCode());
+	}
 
-    public String getTitle() {
-        return title;
-    }
+	public String getTitle() {
+		return title;
+	}
 
-    public void setTitle(String title) {
-        this.title = title;
-    }
+	public void setTitle(String title) {
+		this.title = title;
+	}
 
-    public String getMsg() {
-        return msg;
-    }
+	public String getMsg() {
+		return msg;
+	}
 
-    public void setMsg(String msg) {
-        this.msg = msg;
-    }
+	public void setMsg(String msg) {
+		this.msg = msg;
+	}
 
-    public String getUrl() {
-        return url;
-    }
+	public String getUrl() {
+		return url;
+	}
 
-    public void setUrl(String url) {
-        this.url = url;
-    }
+	public void setUrl(String url) {
+		this.url = url;
+	}
 
-    public String getUrlTitle() {
-        return urlTitle;
-    }
+	public String getUrlTitle() {
+		return urlTitle;
+	}
 
-    public void setUrlTitle(String urlTitle) {
-        this.urlTitle = urlTitle;
-    }
+	public void setUrlTitle(String urlTitle) {
+		this.urlTitle = urlTitle;
+	}
 
-    public boolean isDismissible() {
-        return isDismissible;
-    }
+	public boolean isDismissible() {
+		return isDismissible;
+	}
 
-    public void setDismissible(boolean isDismissible) {
-        this.isDismissible = isDismissible;
-    }
+	public void setDismissible(boolean isDismissible) {
+		this.isDismissible = isDismissible;
+	}
 }

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBox.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBox.java
@@ -25,8 +25,8 @@ public class InfoBox {
 	private boolean isDismissible = false;
 
 	public String getInfoId() {
-		return Integer
-				.toString(getTitle().hashCode() + getMsg().hashCode() + getUrl().hashCode() + getUrlTitle().hashCode());
+		return Integer.toString(getTitle().hashCode() + getMsg().hashCode() + getUrl().hashCode()
+				+ getUrlTitle().hashCode() + Boolean.hashCode(getIsDismissible()));
 	}
 
 	public String getTitle() {

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBox.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBox.java
@@ -11,8 +11,7 @@
 package org.dpppt.switzerland.backend.sdk.config.ws.model;
 
 /**
- * @author bachmann
- * created on 28.04.20
+ * @author bachmann created on 28.04.20
  **/
 public class InfoBox {
 
@@ -20,6 +19,11 @@ public class InfoBox {
     private String msg;
     private String url;
     private String urlTitle;
+    private boolean isDismissible = false;
+
+    public String getInfoId() {
+        return Integer.toString(getTitle().hashCode() + getMsg().hashCode() + getUrl().hashCode() + getUrlTitle().hashCode());
+    }
 
     public String getTitle() {
         return title;
@@ -51,5 +55,13 @@ public class InfoBox {
 
     public void setUrlTitle(String urlTitle) {
         this.urlTitle = urlTitle;
+    }
+
+    public boolean isDismissible() {
+        return isDismissible;
+    }
+
+    public void setDismissible(boolean isDismissible) {
+        this.isDismissible = isDismissible;
     }
 }

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBox.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBox.java
@@ -61,11 +61,11 @@ public class InfoBox {
 		this.urlTitle = urlTitle;
 	}
 
-	public boolean isDismissible() {
+	public boolean getIsDismissible() {
 		return isDismissible;
 	}
 
-	public void setDismissible(boolean isDismissible) {
+	public void setIsDismissible(boolean isDismissible) {
 		this.isDismissible = isDismissible;
 	}
 }

--- a/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
+++ b/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
@@ -135,11 +135,16 @@ public abstract class BaseControllerTest {
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "1.0.5").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-		assertTestNoUpdate(result);
+		assertTestNormalUpdate(result);
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.6").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-		assertTestNoUpdate(result);
+		assertTestNormalUpdate(result);
+		
+		result = mockMvc.perform(
+				get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.7").param("buildnr", "ios-2020.0145asdfa34"))
+				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+			assertTestNoUpdate(result);
 	}
 	@Test
 	public void testForTestflight() throws Exception {
@@ -155,7 +160,7 @@ public abstract class BaseControllerTest {
 			assertTestTestflightUpdate(result);
 		}
 		final MockHttpServletResponse result = mockMvc.perform(
-				get("/v1/config").param("osversion", "ios12").param("appversion", "1.0.5").param("buildnr", "ios-200521.2320.80"))
+				get("/v1/config").param("osversion", "ios12").param("appversion", "1.0.7").param("buildnr", "ios-200521.2320.80"))
 				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
 		assertTestNoUpdate(result);
 	}


### PR DESCRIPTION
This PR adds a flag to the info boxes, so that infoboxes can be dismissed by users of the mobile app. To identify infoboxes, an id is introduced, which is calculated from the content of the infobox: title, msg, url, urltitle and dismissible flag.

Additionally, the App Update infobox is shown up to app version < 1.0.7