### PR TITLE
revert back to 1.0.5 update note

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -66,10 +66,10 @@ public class DPPPTConfigController {
 		}
 
 		// update message for various old builds
-		var appVersion = new Version(appversion);
-		if (!appVersion.isValid() || appVersion.isSmallerVersionThan(CURRENT_RELEASE_VERSION)) {
-			config = generalUpdateRelease1(appVersion.isIOS());
-		}
+		// var appVersion = new Version(appversion);
+		// if (!appVersion.isValid() || appVersion.isSmallerVersionThan(CURRENT_RELEASE_VERSION)) {
+		// 	config = generalUpdateRelease1(appVersion.isIOS());
+		// }
 
 		// if we have testflight builds suggest to switch to store version
 		if (TESTFLIGHT_VERSIONS.contains(buildnr)) {

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequestMapping("/v1")
 public class DPPPTConfigController {
 	
-	private static final Version CURRENT_RELEASE_VERSION = new Version("1.0.7");
+	private static final Version CURRENT_RELEASE_VERSION = new Version("1.0.5");
 	private static final String IOS_VERSION_DE_WEEKLY_NOTIFCATION_INFO = "ios13.6";
 	private static final List<String> TESTFLIGHT_VERSIONS = List.of("ios-200619.2333.175", 
 			   "ios-200612.2347.141",

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -33,7 +33,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequestMapping("/v1")
 public class DPPPTConfigController {
 	
-	private static final Version CURRENT_RELEASE_VERSION = new Version("1.0.5");
 	private static final String IOS_VERSION_DE_WEEKLY_NOTIFCATION_INFO = "ios13.6";
 	private static final List<String> TESTFLIGHT_VERSIONS = List.of("ios-200619.2333.175", 
 			   "ios-200612.2347.141",
@@ -64,12 +63,6 @@ public class DPPPTConfigController {
 		if (osversion.equals(IOS_VERSION_DE_WEEKLY_NOTIFCATION_INFO)) {
 			setInfoTextForiOS136DE(config);
 		}
-
-		// update message for various old builds
-		// var appVersion = new Version(appversion);
-		// if (!appVersion.isValid() || appVersion.isSmallerVersionThan(CURRENT_RELEASE_VERSION)) {
-		// 	config = generalUpdateRelease1(appVersion.isIOS());
-		// }
 
 		// if we have testflight builds suggest to switch to store version
 		if (TESTFLIGHT_VERSIONS.contains(buildnr)) {

--- a/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
+++ b/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
@@ -111,27 +111,27 @@ public abstract class BaseControllerTest {
 		MockHttpServletResponse result = mockMvc.perform(
 				get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.0").param("buildnr", "ios-2020.0145asdfa34"))
 				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-		assertTestNormalUpdate(result);
+			assertTestNoUpdate(result);
 		result = mockMvc.perform(
 				get("/v1/config").param("osversion", "ios12").param("appversion", "android-1.0.1").param("buildnr", "ios-2020.0145asdfa34"))
 				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-		assertTestNormalUpdate(result);
+			assertTestNoUpdate(result);
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.2").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-		assertTestNormalUpdate(result);
+			assertTestNoUpdate(result);
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "android-1.0").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-		assertTestNormalUpdate(result);
+			assertTestNoUpdate(result);
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "1.0.3").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-		assertTestNormalUpdate(result);
+			assertTestNoUpdate(result);
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "android-1.0.4").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-		assertTestNormalUpdate(result);
+			assertTestNoUpdate(result);
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "1.0.5").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();

--- a/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
+++ b/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
@@ -135,11 +135,11 @@ public abstract class BaseControllerTest {
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "1.0.5").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-		assertTestNormalUpdate(result);
+			assertTestNoUpdate(result);
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.6").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-		assertTestNormalUpdate(result);
+			assertTestNoUpdate(result);
 		
 		result = mockMvc.perform(
 				get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.7").param("buildnr", "ios-2020.0145asdfa34"))


### PR DESCRIPTION
App versions 1.0.7 and 1.0.8 do not refresh config request upon start of the app anymore (only if older than 12h). This means the update infobox does not go away after updating the app (until 4-12h later). Disable update infobox until the next app-update reloads the config after app-update.