### PR TITLE
Removal of DPKConfig

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/config/WSBaseConfig.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/config/WSBaseConfig.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
-import org.dpppt.switzerland.backend.sdk.config.ws.controller.DPPPTConfigController;
+import org.dpppt.switzerland.backend.sdk.config.ws.controller.GaenConfigController;
 import org.dpppt.switzerland.backend.sdk.config.ws.filter.ResponseWrapperFilter;
 import org.dpppt.switzerland.backend.sdk.config.ws.interceptor.HeaderInjector;
 import org.dpppt.switzerland.backend.sdk.config.ws.model.ConfigResponse;
@@ -79,8 +79,8 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 	}
 
 	@Bean
-	public DPPPTConfigController dppptSDKController(Messages messages) {
-		return new DPPPTConfigController(messages);
+	public GaenConfigController gaenConfigController(Messages messages) {
+		return new GaenConfigController(messages);
 	}
 
 	@Bean

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/GaenConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/GaenConfigController.java
@@ -21,7 +21,6 @@ import org.dpppt.switzerland.backend.sdk.config.ws.poeditor.Messages;
 import org.dpppt.switzerland.backend.sdk.config.ws.semver.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Bean;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -33,7 +32,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping("/v1")
-public class DPPPTConfigController {
+public class GaenConfigController {
 
     private static final String IOS_VERSION_DE_WEEKLY_NOTIFCATION_INFO = "ios13.6";
     private static final List<String> TESTFLIGHT_VERSIONS = List.of("ios-200619.2333.175",
@@ -46,11 +45,11 @@ public class DPPPTConfigController {
     private static final Version APP_VERSION_1_0_9 = new Version("ios-1.0.9");
     private static final Version IOS_APP_VERSION_1_1_2 = new Version("ios-1.1.2");
 
-    private static final Logger logger = LoggerFactory.getLogger(DPPPTConfigController.class);
+    private static final Logger logger = LoggerFactory.getLogger(GaenConfigController.class);
 
     private static Messages messages;
 
-    public DPPPTConfigController(Messages messages) {
+    public GaenConfigController(Messages messages) {
         this.messages = messages;
     }
 
@@ -197,8 +196,6 @@ public class DPPPTConfigController {
         collection.setSrInfoBox(infoBoxsr);
         configResponse.setInfoBox(collection);
 
-        SDKConfig config = new SDKConfig();
-        configResponse.setSdkConfig(config);
         return configResponse;
 
     }
@@ -343,8 +340,6 @@ public class DPPPTConfigController {
 
         configResponse.setInfoBox(collection);
 
-        SDKConfig config = new SDKConfig();
-        configResponse.setSdkConfig(config);
         return configResponse;
     }
 
@@ -421,8 +416,6 @@ public class DPPPTConfigController {
         collection.setSrInfoBox(infoBoxsr);
         configResponse.setInfoBox(collection);
 
-        SDKConfig config = new SDKConfig();
-        configResponse.setSdkConfig(config);
         return configResponse;
     }
 

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/ConfigResponse.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/ConfigResponse.java
@@ -16,25 +16,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class ConfigResponse {
 
 	private boolean forceUpdate = false;
-	private boolean forceTraceShutdown = false;
 
 	private InfoBoxCollection infoBox = null;
 	private WhatToDoPositiveTestTextsCollection whatToDoPositiveTestTexts;
 
-	private SDKConfig sdkConfig = new SDKConfig();
 	private GAENSDKConfig iOSGaenSdkConfig = new GAENSDKConfig();
 	private GAENSDKConfig androidGaenSdkConfig = new GAENSDKConfig();
 
 	public boolean isForceUpdate() {
 		return forceUpdate;
-	}
-
-	public SDKConfig getSdkConfig() {
-		return sdkConfig;
-	}
-
-	public void setSdkConfig(SDKConfig sdkConfig) {
-		this.sdkConfig = sdkConfig;
 	}
 
 	public void setForceUpdate(boolean forceUpdate) {
@@ -56,14 +46,6 @@ public class ConfigResponse {
     public void setWhatToDoPositiveTestTexts(WhatToDoPositiveTestTextsCollection whatToDoPositiveTestTexts) {
         this.whatToDoPositiveTestTexts = whatToDoPositiveTestTexts;
     }
-
-    public boolean isForceTraceShutdown() {
-		return forceTraceShutdown;
-	}
-
-	public void setForceTraceShutdown(boolean forceTraceShutdown) {
-		this.forceTraceShutdown = forceTraceShutdown;
-	}
 
 	public GAENSDKConfig getiOSGaenSdkConfig() {
 		return iOSGaenSdkConfig;

--- a/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/GaenConfigControllerTest.java
+++ b/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/GaenConfigControllerTest.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 	"management.endpoints.enabled-by-default=true",
 	"management.endpoints.web.exposure.include=*"
  })
-public class DPPPTConfigControllerTest extends BaseControllerTest {
+public class GaenConfigControllerTest extends BaseControllerTest {
 	@Autowired
 	private Filter springSecurityFilterChain;
 

--- a/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/GaenConfigControllerWithoutActuatorSecurityTest.java
+++ b/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/GaenConfigControllerWithoutActuatorSecurityTest.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 	"management.endpoints.enabled-by-default=true",
 	"management.endpoints.web.exposure.include=*"
  })
-public class DPPPTConfigControllerWithoutActuatorSecurityTest extends BaseControllerTest {
+public class GaenConfigControllerWithoutActuatorSecurityTest extends BaseControllerTest {
     @Autowired
     ObjectMapper objectMapper;
     


### PR DESCRIPTION
Removes the now obsolete DPKConfig: it has been used in the first version of the app before the GAEN-API.

Closes #68 