### PR TITLE
Merge into master

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -95,7 +95,7 @@ public class DPPPTConfigController {
 				+ " Die App funktioniert weiterhin und zeichnet alle Kontakte auf.");
 		infoBoxDe.setTitle("Hinweis");
 		infoBoxDe.setUrl(
-				"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/faq-kontakte-downloads/haeufig-gestellte-fragen.html?faq-url=/de/categories/swisscovid-app");
+				"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/faq-kontakte-downloads/haeufig-gestellte-fragen.html?faq-url=/de/technik/wieso-erscheint-auf-ios-136-w%C3%B6chtlich-eine-benachrichtigung-dein-ger%C3%A4t-hat-%C2%AB0-m%C3%B6gliche");
 		infoBoxDe.setUrlTitle("Weitere Informationen");
 		infoBoxDe.setIsDismissible(true);
 		InfoBoxCollection infoBoxCollection = new InfoBoxCollection();


### PR DESCRIPTION
This PR changes the url of the infobox that is shown to german users on iOS 13.6. The new url points directly to the FAQ entry explaining the problem.
Also some romanisch strings have been corrected. 