### PR TITLE
Show general Update Info for iOS Users with App < 1.0.9 and iOS < 13.7

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -78,10 +78,17 @@ public class DPPPTConfigController {
 			config.getiOSGaenSdkConfig().setFactorHigh(0.0d);
 		}
 
-		// Show popup to iOS 13.7/14 users who have not yet updated to SwissCovid 1.0.9 (which fixes compatibility issues)
-		if ((osversion.equals(IOS_VERSION_13_7) || osversion.equals(IOS_VERSION_14)) 
-			&& APP_VERSION_1_0_9.isLargerVersionThan(new Version(appversion))) {
-			config.setForceUpdate(true);
+		// Check for old app Versions, iOS only
+		Version userAppVersion = new Version(appversion);
+		if (userAppVersion.isIOS() && APP_VERSION_1_0_9.isLargerVersionThan(userAppVersion)) {
+			// Show popup to iOS 13.7/14 users who have not yet updated to SwissCovid 1.0.9
+			// (which fixes compatibility issues)
+			if ((osversion.equals(IOS_VERSION_13_7) || osversion.equals(IOS_VERSION_14))) {
+				config.setForceUpdate(true);
+			} else {
+				// For < 13.7 users show info that new update is available
+				config = generalUpdateRelease(true);
+			}
 		}
 		return ResponseEntity.ok().cacheControl(CacheControl.maxAge(Duration.ofMinutes(5))).body(config);
 	}
@@ -190,7 +197,7 @@ public class DPPPTConfigController {
 
 	}
 
-	private ConfigResponse generalUpdateRelease1(boolean isIos) {
+	private ConfigResponse generalUpdateRelease(boolean isIos) {
 		ConfigResponse configResponse = new ConfigResponse();
 		String appstoreUrl = isIos ? "https://apps.apple.com/ch/app/id1509275381"
 				: "https://play.google.com/store/apps/details?id=ch.admin.bag.dp3t";
@@ -206,6 +213,8 @@ public class DPPPTConfigController {
 		infoBoxde.setTitle("App-Update verfügbar");
 		infoBoxde.setUrlTitle("Aktualisieren");
 		infoBoxde.setUrl(appstoreUrl);
+		infoBoxde.setIsDismissible(false);
+		
 		InfoBox infoBoxfr = new InfoBox();
 		infoBoxfr.setMsg(
 				"Une nouvelle version de SwissCovid est disponible. Afin que l'application fonctionne au mieux, téléchargez la dernière version sur "
@@ -213,6 +222,8 @@ public class DPPPTConfigController {
 		infoBoxfr.setTitle("Mise à jour disponible");
 		infoBoxfr.setUrlTitle("Mettre à jour");
 		infoBoxfr.setUrl(appstoreUrl);
+		infoBoxfr.setIsDismissible(false);
+		
 		InfoBox infoBoxit = new InfoBox();
 		infoBoxit.setMsg(
 				"È disponibile una versione più recente di SwissCovid. Per ottimizzare la funzionalità dell'app, scarica l'ultima versione da "
@@ -220,6 +231,8 @@ public class DPPPTConfigController {
 		infoBoxit.setTitle("È disponibile un aggiornamento dell'app");
 		infoBoxit.setUrlTitle("Aggiorna");
 		infoBoxit.setUrl(appstoreUrl);
+		infoBoxit.setIsDismissible(false);
+		
 		InfoBox infoBoxen = new InfoBox();
 		infoBoxen.setMsg(
 				"An updated version of SwissCovid is available. To guarantee the app works as well as possible, download the latest version from the "
@@ -227,6 +240,8 @@ public class DPPPTConfigController {
 		infoBoxen.setTitle("App update available");
 		infoBoxen.setUrlTitle("Update");
 		infoBoxen.setUrl(appstoreUrl);
+		infoBoxen.setIsDismissible(false);
+		
 		InfoBox infoBoxpt = new InfoBox();
 		infoBoxpt.setMsg(
 				"Está disponível uma nova versão da SwissCovid. Para que a app trabalhe com toda a eficiência, carregue a versão mais recente a partir da "
@@ -234,6 +249,8 @@ public class DPPPTConfigController {
 		infoBoxpt.setTitle("Atualização da app disponível");
 		infoBoxpt.setUrlTitle("Atualizar");
 		infoBoxpt.setUrl(appstoreUrl);
+		infoBoxpt.setIsDismissible(false);
+		
 		InfoBox infoBoxes = new InfoBox();
 		infoBoxes.setMsg(
 				"Hay una nueva versión de SwissCovid disponible. Para garantizar el mejor funcionamiento posible, descargue siempre la versión más nueva en el "
@@ -241,6 +258,8 @@ public class DPPPTConfigController {
 		infoBoxes.setTitle("Actualización de la app disponible");
 		infoBoxes.setUrlTitle("Actualizar");
 		infoBoxes.setUrl(appstoreUrl);
+		infoBoxes.setIsDismissible(false);
+		
 		InfoBox infoBoxsq = new InfoBox();
 		infoBoxsq.setMsg(
 				"Është i disponueshëm një version i ri nga SwissCovid. Për të marrë mënyrën më të mirë të mundshme të funksionit të aplikacionit, ngarkoni versionin më të ri nga "
@@ -248,6 +267,8 @@ public class DPPPTConfigController {
 		infoBoxsq.setTitle("Update i aplikacionit i disponueshëm");
 		infoBoxsq.setUrlTitle("Përditësimi");
 		infoBoxsq.setUrl(appstoreUrl);
+		infoBoxsq.setIsDismissible(false);
+		
 		InfoBox infoBoxbs = new InfoBox();
 		infoBoxbs.setMsg(
 				"Dostupna je novija verzija aplikacije SwissCovid. Da biste održavali najbolju moguću funkcionalnost aplikacije, preuzmite najnoviju verziju iz trgovine aplikacijama "
@@ -255,6 +276,8 @@ public class DPPPTConfigController {
 		infoBoxbs.setTitle("Dostupno ažuriranje aplikacije");
 		infoBoxbs.setUrlTitle("Ažuriraj");
 		infoBoxbs.setUrl(appstoreUrl);
+		infoBoxbs.setIsDismissible(false);
+		
 		InfoBox infoBoxhr = new InfoBox();
 		infoBoxhr.setMsg(
 				"Dostupna je novija verzija aplikacije SwissCovid. Da biste održavali najbolju moguću funkcionalnost aplikacije, preuzmite najnoviju verziju iz trgovine aplikacijama "
@@ -262,12 +285,16 @@ public class DPPPTConfigController {
 		infoBoxhr.setTitle("Dostupno ažuriranje aplikacije");
 		infoBoxhr.setUrlTitle("Ažuriraj");
 		infoBoxhr.setUrl(appstoreUrl);
+		infoBoxhr.setIsDismissible(false);
+		
 		InfoBox infoBoxrm = new InfoBox();
 		infoBoxrm.setMsg("Ina versiun pli nova da SwissCovid è disponibla. Chargiai giu l'ultima versiun " + storeRm
 				+ ", per che l'app funcziunia il meglier pussaivel.");
 		infoBoxrm.setTitle("Actualisaziun da l'app è disponibla");
 		infoBoxrm.setUrlTitle("Actualisar");
 		infoBoxrm.setUrl(appstoreUrl);
+		infoBoxrm.setIsDismissible(false);
+
 		InfoBox infoBoxsr = new InfoBox();
 		infoBoxsr.setMsg(
 				"Dostupna je novija verzija aplikacije SwissCovid. Da biste održavali najbolju moguću funkcionalnost aplikacije, preuzmite najnoviju verziju iz trgovine aplikacijama "
@@ -275,6 +302,26 @@ public class DPPPTConfigController {
 		infoBoxsr.setTitle("Dostupno ažuriranje aplikacije");
 		infoBoxsr.setUrlTitle("Ažuriraj");
 		infoBoxsr.setUrl(appstoreUrl);
+		infoBoxsr.setIsDismissible(false);
+		
+		InfoBox infoBoxtr = new InfoBox();
+		infoBoxtr.setMsg(
+				"An updated version of SwissCovid is available. To guarantee the app works as well as possible, download the latest version from the "
+						+ store);
+		infoBoxtr.setTitle("App update available");
+		infoBoxtr.setUrlTitle("Update");
+		infoBoxtr.setUrl(appstoreUrl);
+		infoBoxtr.setIsDismissible(false);
+		
+		
+		InfoBox infoBoxti = new InfoBox();
+		infoBoxti.setMsg(
+				"An updated version of SwissCovid is available. To guarantee the app works as well as possible, download the latest version from the "
+						+ store);
+		infoBoxti.setTitle("App update available");
+		infoBoxti.setUrlTitle("Update");
+		infoBoxti.setUrl(appstoreUrl);
+		infoBoxti.setIsDismissible(false);
 
 		InfoBoxCollection collection = new InfoBoxCollection();
 		collection.setDeInfoBox(infoBoxde);
@@ -288,6 +335,9 @@ public class DPPPTConfigController {
 		collection.setBsInfoBox(infoBoxbs);
 		collection.setRmInfoBox(infoBoxrm);
 		collection.setSrInfoBox(infoBoxsr);
+		collection.setTiInfobox(infoBoxti);
+		collection.setTrInfobox(infoBoxtr);
+		
 		configResponse.setInfoBox(collection);
 
 		SDKConfig config = new SDKConfig();

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBoxCollection.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBoxCollection.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @JsonInclude(value = Include.NON_NULL)
 public class InfoBoxCollection {
-	
+
 	private InfoBox deInfoBox;
 	private InfoBox frInfoBox;
 	private InfoBox itInfoBox;
@@ -27,6 +27,8 @@ public class InfoBoxCollection {
 	private InfoBox hrInfoBox;
 	private InfoBox srInfoBox;
 	private InfoBox rmInfoBox;
+	private InfoBox trInfobox;
+	private InfoBox tiInfobox;
 
 	public InfoBox getPtInfoBox() {
 		return this.ptInfoBox;
@@ -114,5 +116,21 @@ public class InfoBoxCollection {
 
 	public void setDeInfoBox(InfoBox deInfoBox) {
 		this.deInfoBox = deInfoBox;
+	}
+
+	public InfoBox getTrInfobox() {
+		return trInfobox;
+	}
+
+	public void setTrInfobox(InfoBox trInfobox) {
+		this.trInfobox = trInfobox;
+	}
+
+	public InfoBox getTiInfobox() {
+		return tiInfobox;
+	}
+
+	public void setTiInfobox(InfoBox tiInfobox) {
+		this.tiInfobox = tiInfobox;
 	}
 }

--- a/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
+++ b/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
@@ -75,6 +75,11 @@ public abstract class BaseControllerTest {
 		assertNotNull(resp.getInfoBox().getDeInfoBox());
 		assertEquals("App-Update im App Store", resp.getInfoBox().getDeInfoBox().getTitle());
 	}
+	
+	private void assertIsForceUpdate(MockHttpServletResponse result) throws Exception {
+		ConfigResponse resp = objectMapper.readValue(result.getContentAsString(Charset.forName("utf-8")), ConfigResponse.class);
+		assertTrue(resp.isForceUpdate());
+	}
 
 	@Test
 	public void testHello() throws Exception {
@@ -109,7 +114,7 @@ public abstract class BaseControllerTest {
 	@Test
 	public void testForUpdateNote() throws Exception {
 		MockHttpServletResponse result = mockMvc.perform(
-				get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.0").param("buildnr", "ios-2020.0145asdfa34"))
+				get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.9").param("buildnr", "ios-2020.0145asdfa34"))
 				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
 			assertTestNoUpdate(result);
 		result = mockMvc.perform(
@@ -117,9 +122,9 @@ public abstract class BaseControllerTest {
 				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
 			assertTestNoUpdate(result);
 		result = mockMvc.perform(
-			get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.2").param("buildnr", "ios-2020.0145asdfa34"))
+			get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.8").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-			assertTestNoUpdate(result);
+			assertTestNormalUpdate(result);
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "android-1.0").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
@@ -139,13 +144,37 @@ public abstract class BaseControllerTest {
 		result = mockMvc.perform(
 			get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.6").param("buildnr", "ios-2020.0145asdfa34"))
 			.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-			assertTestNoUpdate(result);
+			assertTestNormalUpdate(result);
 		
 		result = mockMvc.perform(
 				get("/v1/config").param("osversion", "ios12").param("appversion", "ios-1.0.7").param("buildnr", "ios-2020.0145asdfa34"))
 				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+			assertTestNormalUpdate(result);				
+	
+		result = mockMvc.perform(
+				get("/v1/config").param("osversion", "ios13.7").param("appversion", "ios-1.0.9").param("buildnr", "ios-2020.0145asdfa34"))
+				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
 			assertTestNoUpdate(result);
+		result = mockMvc.perform(
+					get("/v1/config").param("osversion", "ios14").param("appversion", "ios-1.0.9").param("buildnr", "ios-2020.0145asdfa34"))
+					.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+				assertTestNoUpdate(result);			
 	}
+	
+	@Test
+	public void testForceUpdate() throws Exception {
+		MockHttpServletResponse result = mockMvc.perform(
+				get("/v1/config").param("osversion", "ios14").param("appversion", "ios-1.0.8").param("buildnr", "ios-2020.0145asdfa34"))
+				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+			assertIsForceUpdate(result);	
+			
+		result = mockMvc.perform(
+					get("/v1/config").param("osversion", "ios13.7").param("appversion", "ios-1.0.7").param("buildnr", "ios-2020.0145asdfa34"))
+					.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+				assertIsForceUpdate(result);			
+	}
+
+
 	@Test
 	public void testForTestflight() throws Exception {
 		final List<String> testflightVersions = List.of("ios-200619.2333.175", 


### PR DESCRIPTION
This PR adds an non dismissible infobox for all iOS users with os Version < 13.7 that do not have the latest version of the SwissCovid app installed. The infobox asks users to install the latest version from the app store.

The infobox is needed due to a bug when updating to iOS 13.7: It is important that all users install SwissCovid version 1.0.9. Otherwise the app might not work as expected after updating the os.