### PR TITLE
Show info popup about update instead of force update

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -81,14 +81,7 @@ public class DPPPTConfigController {
 		// Check for old app Versions, iOS only
 		Version userAppVersion = new Version(appversion);
 		if (userAppVersion.isIOS() && APP_VERSION_1_0_9.isLargerVersionThan(userAppVersion)) {
-			// Show popup to iOS 13.7/14 users who have not yet updated to SwissCovid 1.0.9
-			// (which fixes compatibility issues)
-			if ((osversion.equals(IOS_VERSION_13_7) || osversion.equals(IOS_VERSION_14))) {
-				config.setForceUpdate(true);
-			} else {
-				// For < 13.7 users show info that new update is available
-				config = generalUpdateRelease(true);
-			}
+			config = generalUpdateRelease(true);
 		}
 		return ResponseEntity.ok().cacheControl(CacheControl.maxAge(Duration.ofMinutes(5))).body(config);
 	}

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/DPPPTConfigController.java
@@ -40,7 +40,7 @@ public class DPPPTConfigController {
 			   "ios-200524.1316.87",
 			   "ios-200521.2320.79");
 	private static final String IOS_VERSION_13_7 = "ios13.7";
-	private static final String IOS_VERSION_14 = "ios14";
+	private static final String IOS_VERSION_14 = "ios14.0";
 	private static final Version APP_VERSION_1_0_9 = new Version("ios-1.0.9");
 
 	private static final Logger logger = LoggerFactory.getLogger(DPPPTConfigController.class);

--- a/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
+++ b/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
@@ -10,7 +10,20 @@
 
 package org.dpppt.switzerland.backend.sdk.config.ws;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.security.PublicKey;
+import java.util.List;
+import java.util.Map;
+
 import org.dpppt.switzerland.backend.sdk.config.ws.filter.ResponseWrapperFilter;
 import org.dpppt.switzerland.backend.sdk.config.ws.model.ConfigResponse;
 import org.junit.Test;
@@ -23,19 +36,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import static org.junit.Assert.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.security.PublicKey;
-import java.util.List;
-import java.util.Map;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.jsonwebtoken.Jwts;
 
@@ -76,9 +77,9 @@ public abstract class BaseControllerTest {
 		assertEquals("App-Update im App Store", resp.getInfoBox().getDeInfoBox().getTitle());
 	}
 	
-	private void assertIsForceUpdate(MockHttpServletResponse result) throws Exception {
+	private void assertIsNoForceUpdate(MockHttpServletResponse result) throws Exception {
 		ConfigResponse resp = objectMapper.readValue(result.getContentAsString(Charset.forName("utf-8")), ConfigResponse.class);
-		assertTrue(resp.isForceUpdate());
+		assertFalse(resp.isForceUpdate());
 	}
 
 	@Test
@@ -162,16 +163,16 @@ public abstract class BaseControllerTest {
 	}
 	
 	@Test
-	public void testForceUpdate() throws Exception {
+	public void testNoForceUpdate() throws Exception {
 		MockHttpServletResponse result = mockMvc.perform(
 				get("/v1/config").param("osversion", "ios14.0").param("appversion", "ios-1.0.8").param("buildnr", "ios-2020.0145asdfa34"))
 				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-			assertIsForceUpdate(result);	
+			assertIsNoForceUpdate(result);	
 			
 		result = mockMvc.perform(
 					get("/v1/config").param("osversion", "ios13.7").param("appversion", "ios-1.0.7").param("buildnr", "ios-2020.0145asdfa34"))
 					.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-				assertIsForceUpdate(result);			
+				assertIsNoForceUpdate(result);			
 	}
 
 

--- a/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
+++ b/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/BaseControllerTest.java
@@ -164,7 +164,7 @@ public abstract class BaseControllerTest {
 	@Test
 	public void testForceUpdate() throws Exception {
 		MockHttpServletResponse result = mockMvc.perform(
-				get("/v1/config").param("osversion", "ios14").param("appversion", "ios-1.0.8").param("buildnr", "ios-2020.0145asdfa34"))
+				get("/v1/config").param("osversion", "ios14.0").param("appversion", "ios-1.0.8").param("buildnr", "ios-2020.0145asdfa34"))
 				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
 			assertIsForceUpdate(result);	
 			


### PR DESCRIPTION
Due to a bug in SwissCovid 1.0.9 for iOS the force-update popup is only removed after 6h instead of directly after updating the app. Until this bug is resolved we will show an infobox instead.