### PR TITLE
add unit test to verify texts are correctly loaded for each language by Messages

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/config/WSBaseConfig.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/config/WSBaseConfig.java
@@ -33,7 +33,6 @@ import org.dpppt.switzerland.backend.sdk.config.ws.filter.ResponseWrapperFilter;
 import org.dpppt.switzerland.backend.sdk.config.ws.interceptor.HeaderInjector;
 import org.dpppt.switzerland.backend.sdk.config.ws.model.ConfigResponse;
 import org.dpppt.switzerland.backend.sdk.config.ws.model.FaqEntry;
-import org.dpppt.switzerland.backend.sdk.config.ws.model.InfoBox;
 import org.dpppt.switzerland.backend.sdk.config.ws.model.WhatToDoPositiveTestTexts;
 import org.dpppt.switzerland.backend.sdk.config.ws.model.WhatToDoPositiveTestTextsCollection;
 import org.dpppt.switzerland.backend.sdk.config.ws.poeditor.Messages;

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/config/WSBaseConfig.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/config/WSBaseConfig.java
@@ -171,13 +171,11 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
         return new WhatToDoPositiveTestTexts() {
             {
                 setEnterCovidcodeBoxSupertitle(
-                        messages.getNullableMessage("inform_detail_box_subtitle", locale));
-                setEnterCovidcodeBoxTitle(
-                        messages.getNullableMessage("inform_detail_box_title", locale));
-                setEnterCovidcodeBoxText(
-                        messages.getNullableMessage("inform_detail_box_text", locale));
+                        messages.getMessage("inform_detail_box_subtitle", locale));
+                setEnterCovidcodeBoxTitle(messages.getMessage("inform_detail_box_title", locale));
+                setEnterCovidcodeBoxText(messages.getMessage("inform_detail_box_text", locale));
                 setEnterCovidcodeBoxButtonTitle(
-                        messages.getNullableMessage("inform_detail_box_button", locale));
+                        messages.getMessage("inform_detail_box_button", locale));
 
                 setInfoBox(null); // no infobox needed at the moment
 
@@ -186,16 +184,20 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
                                 new FaqEntry() {
                                     {
                                         setTitle(
-                                                messages.getNullableMessage(
+                                                messages.getMessage(
                                                         "inform_detail_faq1_title", locale));
                                         setText(
-                                                messages.getNullableMessage(
+                                                messages.getMessage(
                                                         "inform_detail_faq1_text", locale));
                                         setLinkTitle(
-                                                messages.getNullableMessage(
+                                                messages.getMessage(
                                                         "infoline_coronavirus_number", locale));
-                                        setLinkUrl("tel://"+messages.getNullableMessage(
-												"infoline_coronavirus_number", locale).replace(" ", ""));
+                                        setLinkUrl(
+                                                "tel://"
+                                                        + messages.getMessage(
+                                                                        "infoline_coronavirus_number",
+                                                                        locale)
+                                                                .replace(" ", ""));
                                         setIconAndroid("ic_verified_user");
                                         setIconIos("ic-verified-user");
                                     }
@@ -203,27 +205,27 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
                                 new FaqEntry() {
                                     {
                                         setTitle(
-                                                messages.getNullableMessage(
+                                                messages.getMessage(
                                                         "inform_detail_faq2_title", locale));
                                         setText(
-                                                messages.getNullableMessage(
+                                                messages.getMessage(
                                                         "inform_detail_faq2_text", locale));
                                         setIconAndroid("ic_key");
                                         setIconIos("ic-key");
                                     }
                                 },
-								new FaqEntry() {
-									{
-										setTitle(
-												messages.getNullableMessage(
-														"inform_detail_faq3_title", locale));
-										setText(
-												messages.getNullableMessage(
-														"inform_detail_faq3_text", locale));
-										setIconAndroid("ic_person");
-										setIconIos("ic-user");
-									}
-								}));
+                                new FaqEntry() {
+                                    {
+                                        setTitle(
+                                                messages.getMessage(
+                                                        "inform_detail_faq3_title", locale));
+                                        setText(
+                                                messages.getMessage(
+                                                        "inform_detail_faq3_text", locale));
+                                        setIconAndroid("ic_person");
+                                        setIconIos("ic-user");
+                                    }
+                                }));
             }
         };
     }

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/poeditor/Messages.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/poeditor/Messages.java
@@ -23,25 +23,22 @@ public class Messages {
     }
 
     /**
-     * returns message for the given message key and locale. fallback language: EN. returns message
-     * key if no such message exists
+     * returns message for the given message key and locale.
+     * throws a {@link NoSuchMessageException} if no such message exists
      *
      * @param messageKey
      * @param locale
      * @return
      */
-    public String getMessage(String messageKey, Locale locale) {
-        String message = getNullableMessage(messageKey, locale);
-        if (message == null) {
-            return messageKey;
-        }
-        return message;
+    public String getMessage(String messageKey, Locale locale) throws NoSuchMessageException {
+        return messageSource.getMessage(messageKey, null, locale);
     }
 
     /**
-     * returns message for the given messagekey and locale. fallback language: EN. returns null if
-     * no such message exists flag to disable error logging if the method call is only to check
-     * whether a message for the given key exists
+     * FOR USE DURING DEVELOPMENT WHEN NOT ALL TRANSLATIONS ARE PRESENT
+     * returns message for the given messagekey and locale.
+     * fallback language: EN
+     * returns null if no such message exists.
      *
      * @param messageKey
      * @param locale

--- a/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/MessagesTest.java
+++ b/dpppt-config-backend/src/test/java/org/dpppt/switzerland/backend/sdk/config/ws/MessagesTest.java
@@ -1,0 +1,61 @@
+package org.dpppt.switzerland.backend.sdk.config.ws;
+
+import static org.junit.Assert.assertEquals;
+
+import org.dpppt.switzerland.backend.sdk.config.ws.model.ConfigResponse;
+import org.dpppt.switzerland.backend.sdk.config.ws.model.WhatToDoPositiveTestTextsCollection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles({"cloud-dev"})
+public class MessagesTest {
+
+    @Test
+    public void testWHatToDoPositiveTestTextLanguage() throws Exception {
+        ConfigResponse configResponse = new ConfigResponse();
+        WhatToDoPositiveTestTextsCollection whatToDoPositiveTestTexts =
+                configResponse.getWhatToDoPositiveTestTexts();
+        assertEquals(
+                "Mit dem Covidcode...",
+                whatToDoPositiveTestTexts.getDe().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "Avec le code COVID…",
+                whatToDoPositiveTestTexts.getFr().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "Con il codice Covid...",
+                whatToDoPositiveTestTexts.getIt().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "With the Covidcode",
+                whatToDoPositiveTestTexts.getEn().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "Com o código COVID...",
+                whatToDoPositiveTestTexts.getPt().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "Con el código Covid…",
+                whatToDoPositiveTestTexts.getEs().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "Me kodin Covid...",
+                whatToDoPositiveTestTexts.getSq().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "Sa Covid šifrom...",
+                whatToDoPositiveTestTexts.getBs().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "Sa Covid šifrom...",
+                whatToDoPositiveTestTexts.getHr().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "Sa Covid šifrom...",
+                whatToDoPositiveTestTexts.getSr().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "Cun il code covid...",
+                whatToDoPositiveTestTexts.getRm().getEnterCovidcodeBoxSupertitle());
+        assertEquals(
+                "Kovid kodu ile...",
+                whatToDoPositiveTestTexts.getTr().getEnterCovidcodeBoxSupertitle());
+        assertEquals("ብኮቪድኮድ", whatToDoPositiveTestTexts.getTi().getEnterCovidcodeBoxSupertitle());
+    }
+}


### PR DESCRIPTION
This PR changes the behavior of loading translations to fail when not translated yet and adds a unit test