### PR TITLE
Update text on "What to do if ... you test positive"

### DIFF
--- a/dpppt-config-backend/getTranslations.py
+++ b/dpppt-config-backend/getTranslations.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+
+import http.client, urllib.request, urllib.parse, urllib.error
+import subprocess
+import json
+import sys
+
+def loadLanguage( language, apiToken ):
+    params = urllib.parse.urlencode({'api_token': apiToken, 'action': 'view_terms', 'id': '334421', 'type': 'json', 'language': language})
+    headers = {"Content-type": "application/x-www-form-urlencoded",
+                "Accept": "text/plain"}
+    conn = http.client.HTTPSConnection("poeditor.com")
+    conn.request("POST", "/api/", params, headers)
+    response = conn.getresponse()
+    data = response.read()
+    conn.close()
+
+    results = json.loads(data.decode('utf-8'))    # obj now contains a dict of the data
+
+    if results['response']['code'] == '200':
+        # Open file
+        fo = open("src/main/resources/i18n/messages_"+language+".properties", "wb")
+
+        lineUtf8 = (language + ": \n").encode('UTF-8')
+        fo.write(lineUtf8)
+
+        for translation in results['list']:
+            if translation['definition']['form'] != "":
+                val = translation['definition']['form']
+                val = val.replace("\n", "\\n")
+                lineUtf8 = ("    " + translation['term'] + ": " + val + "\n").encode('UTF-8')
+                fo.write(lineUtf8)
+
+        # Close opend file
+        fo.close()
+    else:
+        print("poeditor API responded with error code: " + results['response']['code'])
+        sys.exit(1)
+
+
+def getApiToken():
+    p1 = subprocess.Popen(["source ~/.zshrc; getPassword 'POEditor API Token'"], stdout=subprocess.PIPE, shell=True, executable='/bin/zsh')
+    output, err = p1.communicate()
+    if err:
+        sys.stderr.write(err.decode("utf-8"))
+    return output.decode("utf-8").splitlines()[-1].split()[0]
+
+apiToken = getApiToken()
+print('Using API token: ' + apiToken)
+
+loadLanguage("sq", apiToken) # albanian
+loadLanguage("bs", apiToken) # bosnian
+loadLanguage("hr", apiToken) # croatian
+loadLanguage("en", apiToken) # english
+loadLanguage("fr", apiToken) # french
+loadLanguage("de", apiToken) # german
+loadLanguage("it", apiToken) # italian
+loadLanguage("pt", apiToken) # portuguese
+loadLanguage("rm", apiToken) # romansh
+loadLanguage("sr", apiToken) # serbian
+loadLanguage("es", apiToken) # spanish
+loadLanguage("ti", apiToken) # tigrinya
+loadLanguage("tr", apiToken) # turkish
+
+print('Successfully loaded terms')

--- a/dpppt-config-backend/src/main/resources/i18n/messages_bs.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_bs.properties
@@ -209,7 +209,7 @@ bs:
     no_meldungen_box_link: Evo kako da se zaštitimo
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Šta je Covid šifra?
-    inform_detail_faq1_text: Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.\n\nRezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 2 sata?\nU tom slučaju, obratite se info liniji za virus korona.
+    inform_detail_faq1_text: Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.\n\nRezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 4 sata?\nU tom slučaju, obratite se info liniji za virus korona.
     inform_detail_faq2_title: Šta se šalje?
     inform_detail_faq2_text: Šalju se samo nasumični ID-ovi iz vaše aplikacije, a ne šalju se lični podaci.\n\nTime drugi korisnici aplikacije SwissCovid mogu da saznaju da postoji mogućnost infekcije.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ bs:
     accessibility_faq_button_hint_non_bag: Ovo dugme napušta aplikaciju i otvara veb stranicu.
     begegnung_detail_no_last_sync_accessibility: Nema prethodnih sinhronizacija
     meldungen_background_error_text_android: Promenite podešavanja da biste dobijali obaveštenja o novoj poruci takođe i izvan aplikacije.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Statistika
     stats_title: već koristi SwissCovid

--- a/dpppt-config-backend/src/main/resources/i18n/messages_de.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_de.properties
@@ -209,7 +209,7 @@ de:
     no_meldungen_box_link: So schützen wir uns
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Was ist ein Covidcode?
-    inform_detail_faq1_text: Positiv auf das neue Coronavirus getestete Personen erhalten einen Covidcode.\n\nDamit wird sichergestellt, dass nur bestätigte Fälle über die App gemeldet werden.\n\nSie wurden positiv getestet und haben nach 2h noch keinen Covidcode erhalten?\nDann kontaktieren Sie die Infoline Coronavirus:
+    inform_detail_faq1_text: Positiv auf das neue Coronavirus getestete Personen erhalten einen Covidcode.\n\nDamit wird sichergestellt, dass nur bestätigte Fälle über die App gemeldet werden.\n\nSie wurden positiv getestet und haben nach 4h noch keinen Covidcode erhalten?\nDann kontaktieren Sie die Infoline Coronavirus:
     inform_detail_faq2_title: Was wird gesendet?
     inform_detail_faq2_text: Es werden nur die zufälligen IDs Ihrer App gesendet, keine persönlichen Daten.\n\nDamit erfahren andere SwissCovid App Nutzer, dass die Möglichkeit einer Ansteckung besteht.
     infoline_tel_number: +41 58 387 77 78
@@ -327,7 +327,7 @@ de:
     accessibility_faq_button_hint_non_bag: Dieser Button verlässt die App und öffnet eine Website.
     begegnung_detail_no_last_sync_accessibility: Keine bisherigen Synchronisationen
     meldungen_background_error_text_android: Ändern Sie die Einstellungen, um bei einer neuen Meldung auch ausserhalb der App informiert zu werden.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     tracing_setting_text_ios_13_5: COVID-19-Kontaktmitteilungen
     tracing_setting_text_ios_13_6: COVID-19-Begegnungsmitteilungen
     tracing_setting_text_ios_14_0: Begegnungsmitteilungen
@@ -338,7 +338,7 @@ de:
     stats_legend_new_infections_average: 7-Tage-Schnitt
     stats_legend_entered_covidcodes: Eingegebene Covidcodes
     share_app_supertitle: Gemeinsam...
-    share_app_title: Eine zweite Welle verhindern
+    share_app_title: Ansteckungen verhindern
     share_app_button: App teilen
     share_app_body: Wenn möglichst viele die SwissCovid App nutzen, können wir Infektionsketten frühzeitig unterbrechen.
     share_app_message: Wenn möglichst viele die SwissCovid App nutzen, können wir Infektionsketten frühzeitig unterbrechen.
@@ -359,3 +359,7 @@ de:
     ios_settings_tutorial_step_4_text: Falls noch nicht geschehen, können Sie nun SwissCovid als aktive Region festlegen.
     ios_settings_tutorial_step_4_set_as_aktive_region: Als aktive Region festlegen
     ios_tracing_permission_error_button: So funktionierts
+    meldung_detail_exposed_subtitle_last_encounter: Letzte Begegnung
+    meldung_detail_exposed_subtitle_all_encounters: Alle Begegnungen
+    meldung_detail_exposed_show_all_button: Alle anzeigen
+    meldung_detail_exposed_show_less_button: Weniger anzeigen

--- a/dpppt-config-backend/src/main/resources/i18n/messages_en.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_en.properties
@@ -209,7 +209,7 @@ en:
     no_meldungen_box_link: Protect yourself and others
     no_meldungen_box_url: https://www.foph-coronavirus.ch
     inform_detail_faq1_title: What is a Covidcode?
-    inform_detail_faq1_text: People who have tested positive for the new coronavirus receive a Covidcode. \n\nThis ensures that only confirmed cases are notified via the app.\n\nYou have tested positive and after 2 hours have not yet received a Covidcode? \nIf this is the case, please contact the Coronavirus Infoline:
+    inform_detail_faq1_text: People who have tested positive for the new coronavirus receive a Covidcode. \n\nThis ensures that only confirmed cases are notified via the app.\n\nYou have tested positive and after 4 hours have not yet received a Covidcode? \nIf this is the case, please contact the Coronavirus Infoline:
     inform_detail_faq2_title: What information gets sent?
     inform_detail_faq2_text: Only the random IDs from your app are sent, no personal data. \n\nOther SwissCovid apps can then check if it is possible that they have been infected.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ en:
     accessibility_faq_button_hint_non_bag: This button leaves the app and opens a website.
     begegnung_detail_no_last_sync_accessibility: No previous synchronisations
     meldungen_background_error_text_android: Change the settings to receive notification outside the app as well in the event of a report.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     tracing_setting_text_ios_14_0: Exposure Notifications
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Stats
@@ -343,3 +343,7 @@ en:
     ios_settings_tutorial_step_4_text: If not done already, you can now set SwissCovid as active region.
     ios_settings_tutorial_step_4_set_as_aktive_region: Set As Active Region
     ios_tracing_permission_error_button: How it works
+    meldung_detail_exposed_subtitle_last_encounter: Last encounter
+    meldung_detail_exposed_subtitle_all_encounters: All encounters
+    meldung_detail_exposed_show_all_button: Show all
+    meldung_detail_exposed_show_less_button: Show less

--- a/dpppt-config-backend/src/main/resources/i18n/messages_es.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_es.properties
@@ -209,7 +209,7 @@ es:
     no_meldungen_box_link: Así nos protegemos
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: ¿Qué es el código Covid?
-    inform_detail_faq1_text: Las personas que han dado positivo en el test del nuevo coronavirus reciben un código Covid. \n\nAsí se garantiza que la aplicación solo informe de los casos confirmados.\n\n¿Ha dado usted positivo en el test y no ha recibido el código Covid después de dos horas?\nEn este caso, póngase en contacto con la Infoline Coronavirus:
+    inform_detail_faq1_text: Las personas que han dado positivo en el test del nuevo coronavirus reciben un código Covid. \n\nAsí se garantiza que la aplicación solo informe de los casos confirmados.\n\n¿Ha dado usted positivo en el test y no ha recibido el código Covid después de cuatro horas?\nEn este caso, póngase en contacto con la Infoline Coronavirus:
     inform_detail_faq2_title: ¿Qué es lo que se envía?
     inform_detail_faq2_text: Solamente se envían los ID aleatorios de la aplicación y no los datos personales. \n\nDe esta forma, se informa a otros usuarios de la aplicación SwissCovid de que existe la posibilidad de contagio.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ es:
     accessibility_faq_button_hint_non_bag: Este botón sale de la aplicación y abre una página web.
     begegnung_detail_no_last_sync_accessibility: No hay sincronizaciones previas.
     meldungen_background_error_text_android: Cambie los ajustes para recibir las notificaciones más actuales también fuera de la aplicación.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Datos
     stats_title: ya utilizan SwissCovid

--- a/dpppt-config-backend/src/main/resources/i18n/messages_fr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_fr.properties
@@ -209,7 +209,7 @@ fr:
     no_meldungen_box_link: Voici comment nous protéger
     no_meldungen_box_url: https://ofsp-coronavirus.ch/
     inform_detail_faq1_title: Qu'est-ce qu'un code COVID ?
-    inform_detail_faq1_text: Un code COVID est attribué aux personnes testées positives au nouveau coronavirus.\n\nCela permet d'assurer que seuls les cas confirmés sont signalés via l'application.\n\nVous n'avez toujours pas reçu de code COVID 2h après avoir été testé positif?\nVeuillez contacter l'infoline coronavirus:
+    inform_detail_faq1_text: Un code COVID est attribué aux personnes testées positives au nouveau coronavirus.\n\nCela permet d'assurer que seuls les cas confirmés sont signalés via l'application.\n\nVous n'avez toujours pas reçu de code COVID 4h après avoir été testé positif?\nVeuillez contacter l'infoline coronavirus:
     inform_detail_faq2_title: Qu'est-ce qui est envoyé ?
     inform_detail_faq2_text: Seules les ID aléatoires de votre application sont envoyées, aucune donnée personnelle.\n\nAinsi, d'autres utilisateurs de l'application SwissCovid apprennent qu'ils ont peut-être été infectés.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ fr:
     accessibility_faq_button_hint_non_bag: Ce bouton permet de quitter l'application et\nd'ouvrir un site internet.
     begegnung_detail_no_last_sync_accessibility: Les synchronisations n'ont pas été effectuées.
     meldungen_background_error_text_android: Veuillez modifier les paramètres pour pouvoir recevoir les nouvelles notifications même en dehors de l'application.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     tracing_setting_text_ios_14_0: Notifications d’exposition
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Chiffres

--- a/dpppt-config-backend/src/main/resources/i18n/messages_hr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_hr.properties
@@ -209,7 +209,7 @@ hr:
     no_meldungen_box_link: Evo kako da se zaštitimo
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Šta je Covid šifra?
-    inform_detail_faq1_text: Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.\n\nRezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 2 sata?\nU tom slučaju, obratite se info liniji za virus korona.
+    inform_detail_faq1_text: Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.\n\nRezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 4 sata?\nU tom slučaju, obratite se info liniji za virus korona.
     inform_detail_faq2_title: Šta se šalje?
     inform_detail_faq2_text: Šalju se samo nasumični ID-ovi iz vaše aplikacije, a ne šalju se lični podaci.\n\nTime drugi korisnici aplikacije SwissCovid mogu da saznaju da postoji mogućnost infekcije.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ hr:
     accessibility_faq_button_hint_non_bag: Ovo dugme napušta aplikaciju i otvara veb stranicu.
     begegnung_detail_no_last_sync_accessibility: Nema prethodnih sinhronizacija
     meldungen_background_error_text_android: Promenite podešavanja da biste dobijali obaveštenja o novoj poruci takođe i izvan aplikacije.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Statistika
     stats_title: već koristi SwissCovid

--- a/dpppt-config-backend/src/main/resources/i18n/messages_it.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_it.properties
@@ -209,7 +209,7 @@ it:
     no_meldungen_box_link: Così ci proteggiamo
     no_meldungen_box_url: https://www.ufsp-coronavirus.ch
     inform_detail_faq1_title: Cos'è un codice Covid?
-    inform_detail_faq1_text: Le persone che sono risultate positive al test del nuovo coronavirus ricevono un codice Covid.\n\nIn questo modo si garantisce che l'app segnali soltanto i casi confermati.\n\nSei risultato positivo al test e dopo due ore non hai ancora ricevuto un codice Covid? Allora contatta la Infoline Coronavirus
+    inform_detail_faq1_text: Le persone che sono risultate positive al test del nuovo coronavirus ricevono un codice Covid.\n\nIn questo modo si garantisce che l'app segnali soltanto i casi confermati.\n\nSei risultato positivo al test e dopo quattro ore non hai ancora ricevuto un codice Covid? Allora contatta la Infoline Coronavirus
     inform_detail_faq2_title: Che cosa viene inviato?
     inform_detail_faq2_text: Vengono inviati soltanto gli ID casuali della tua app, non i tuoi dati personali.\n\nGrazie a questi ID, gli altri utenti dell'app SwissCovid vengono a sapere che vi è la possibilità di un contagio.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ it:
     accessibility_faq_button_hint_non_bag: Questo pulsante permette di lasciare l'app e di aprire un sito Internet.
     begegnung_detail_no_last_sync_accessibility: La sincronizzazione non è ancora stata effettuata.
     meldungen_background_error_text_android: Modifica le impostazioni per essere informato anche al di fuori dell'app in caso di nuova segnalazione.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     tracing_setting_text_ios_14_0: Notifiche di esposizione
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Cifre

--- a/dpppt-config-backend/src/main/resources/i18n/messages_pt.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_pt.properties
@@ -209,7 +209,7 @@ pt:
     no_meldungen_box_link: Como nos protegemos
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: O que é um código COVID?
-    inform_detail_faq1_text: As pessoas que testaram positivo para o novo coronavírus recebem um código COVID.\n\nIsto assegura que só os casos confirmados são assinalados na app.\n\nTestou positivo e ainda não recebeu nenhum código COVID ao fim de 2 h?\nNesse caso, contacte a linha informativa coronavírus:
+    inform_detail_faq1_text: As pessoas que testaram positivo para o novo coronavírus recebem um código COVID.\n\nIsto assegura que só os casos confirmados são assinalados na app.\n\nTestou positivo e ainda não recebeu nenhum código COVID ao fim de 4 h?\nNesse caso, contacte a linha informativa coronavírus:
     inform_detail_faq2_title: Que dados são enviados?
     inform_detail_faq2_text: Só são enviados os IDs aleatórios da sua app e nunca dados pessoais.\n\nDesta forma, outros utilizadores da app SwissCovid ficam a saber que existe a possibilidade de um contágio.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ pt:
     accessibility_faq_button_hint_non_bag: Este botão permite sair da aplicação e abrir uma página de internet.
     begegnung_detail_no_last_sync_accessibility: Nenhuma sincronização até agora
     meldungen_background_error_text_android: Altere as definições para receber as notificações também fora da app.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     tracing_setting_text_ios_14_0: Notificações de exposição
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Números

--- a/dpppt-config-backend/src/main/resources/i18n/messages_rm.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_rm.properties
@@ -209,7 +209,7 @@ rm:
     no_meldungen_box_link: Uschia ans protegin nus
     no_meldungen_box_url: https://check.bag-coronavirus.ch
     inform_detail_faq1_title: Tge è in code covid?
-    inform_detail_faq1_text: Persunas ch’èn vegnidas testadas en moda positiva sin il nov coronavirus survegnan in code covid.\n      \nUschia vegni garantì che mo cas confermads vegnan avisads via l'app.\n\nVus essas vegnida testada resp. vegnì testà en moda positiva sin il coronavirus e n'avais suenter 2 uras anc retschavì nagin code covid? Alura contactai l'infoline coronavirus:
+    inform_detail_faq1_text: Persunas ch’èn vegnidas testadas en moda positiva sin il nov coronavirus survegnan in code covid.\n      \nUschia vegni garantì che mo cas confermads vegnan avisads via l'app.\n\nVus essas vegnida testada resp. vegnì testà en moda positiva sin il coronavirus e n'avais suenter 4 uras anc retschavì nagin code covid? Alura contactai l'infoline coronavirus:
     inform_detail_faq2_title: Tge vegn tramess?
     inform_detail_faq2_text: I vegnan tramessas mo las IDs casualas da Vossa app, naginas datas persunalas.\n\nUschia vegnan autras utilisadras ed auters utilisaders da l'app SwissCovid a savair ch'ina  infecziun è pussaivla.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ rm:
     accessibility_faq_button_hint_non_bag: Quest buttun banduna l'app ad avra ina pagina d'internet. 
     begegnung_detail_no_last_sync_accessibility: Naginas sincronisaziuns precedentas
     meldungen_background_error_text_android: Midai la configuraziun per esser infurmà/infurmada tar ina nova communicaziun er ordaifer l'app.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Cifras
     stats_title: dovran gia SwissCovid

--- a/dpppt-config-backend/src/main/resources/i18n/messages_sq.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_sq.properties
@@ -209,7 +209,7 @@ sq:
     no_meldungen_box_link: Kështu mbrohemi ne
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Çfarë është një kod Covid?
-    inform_detail_faq1_text: Personat që kanë rezultuar pozitivë me koronavirusin e ri marrin një kod Covid.\n\nNë këtë mënyrë sigurohet që nga aplikacioni të sinjalizohen vetëm rastet e konfirmuara.\n\nKeni dalë pozitiv dhe pas 2 orësh nuk keni marrë ende asnjë kod Covid?\nAtëherë kontaktoni "Infoline Coronavirus":
+    inform_detail_faq1_text: Personat që kanë rezultuar pozitivë me koronavirusin e ri marrin një kod Covid.\n\nNë këtë mënyrë sigurohet që nga aplikacioni të sinjalizohen vetëm rastet e konfirmuara.\n\nKeni dalë pozitiv dhe pas 4 orësh nuk keni marrë ende asnjë kod Covid?\nAtëherë kontaktoni "Infoline Coronavirus":
     inform_detail_faq2_title: Çfarë dërgohet?
     inform_detail_faq2_text: Dërgohen vetëm ID e rastit të aplikacionit tuaj, asnjë e dhënë personale.\n\nNë këtë mënyrë mësoni përdoruesit e tjerë të alikacionit SwissCovid, të cilët mundësisht janë infektuar.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ sq:
     accessibility_faq_button_hint_non_bag: Ky buton ju largon nga aplikacioni dhe hap një faqe interneti.
     begegnung_detail_no_last_sync_accessibility: Nuk ka sinkronizime të deritanishme
     meldungen_background_error_text_android: Ndryshoni cilësimet, për t'u informuar për një mesazh të ri edhe jashtë aplikacionit.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Shifra
     stats_title: përdorin tashmë "SwissCovid"

--- a/dpppt-config-backend/src/main/resources/i18n/messages_sr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_sr.properties
@@ -209,7 +209,7 @@ sr:
     no_meldungen_box_link: Evo kako da se zaštitimo
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Šta je Covid šifra?
-    inform_detail_faq1_text: Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.\n\nRezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 2 sata?\nU tom slučaju, obratite se info liniji za virus korona.
+    inform_detail_faq1_text: Ljudi koji su testirani pozitivno na novi virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.\n\nRezultat testa je pozitivan, ali niste dobili Covid šifru ni nakon 4 sata?\nU tom slučaju, obratite se info liniji za virus korona.
     inform_detail_faq2_title: Šta se šalje?
     inform_detail_faq2_text: Šalju se samo nasumični ID-ovi iz vaše aplikacije, a ne šalju se lični podaci.\n\nTime drugi korisnici aplikacije SwissCovid mogu da saznaju da postoji mogućnost infekcije.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ sr:
     accessibility_faq_button_hint_non_bag: Ovo dugme napušta aplikaciju i otvara veb stranicu.
     begegnung_detail_no_last_sync_accessibility: Nema prethodnih sinhronizacija
     meldungen_background_error_text_android: Promenite podešavanja da biste dobijali obaveštenja o novoj poruci takođe i izvan aplikacije.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Statistika
     stats_title: već koristi SwissCovid

--- a/dpppt-config-backend/src/main/resources/i18n/messages_ti.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_ti.properties
@@ -209,7 +209,7 @@ ti:
     no_meldungen_box_link: ብኸምዚ መንገዲ ንነብስና ንከላኸል
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: ኮቪድኮድ እንታይ እዩ፧
-    inform_detail_faq1_text: ውጽኢት መርመርኦም ፖዚቲቭ ዝኾኑ ሰባት ኮቪድኮድ ይውሃቦም። ብኸምዚ መንገዲ እቶም ሕማም ዝተረጋገጸሎም ሰባት ጥራይ በቲ ኣፕ ከምዝምዝገቡ ይረጋገጽ። \n\nኣወንታ/ፖሲቲቭ ተመርሚርኩም ድሕሪ 2 ሰዓት ገና ናይ ኮቪድ ኮድ ኣይተወሃብኩም፧\nሽዑ እቲ ኢንፎላይን ኮሮናቫይረስ ርኸቡ ኢኹም፥
+    inform_detail_faq1_text: ውጽኢት መርመርኦም ፖዚቲቭ ዝኾኑ ሰባት ኮቪድኮድ ይውሃቦም። ብኸምዚ መንገዲ እቶም ሕማም ዝተረጋገጸሎም ሰባት ጥራይ በቲ ኣፕ ከምዝምዝገቡ ይረጋገጽ። \n\nኣወንታ/ፖሲቲቭ ተመርሚርኩም ድሕሪ 4 ሰዓት ገና ናይ ኮቪድ ኮድ ኣይተወሃብኩም፧\nሽዑ እቲ ኢንፎላይን ኮሮናቫይረስ ርኸቡ ኢኹም፥
     inform_detail_faq2_title: እንታይ እዩ ዝስደድ፧ 
     inform_detail_faq2_text: እቶምብግምት ዝተሰርዑ መለልዪ ቁጽርታት ጥራይ እዮም ዝስደዱ ። ውልቃቂ ሰነዳት ኣይስደዱን እዮም።  \nብኸምዚ መንገዲ ካልኦት ተጠቀምቲ ስዊስኮቪድ ተኽእሎ መልከፍቲ ሕማም ከምዘሎ ይፈልጡ።
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ ti:
     accessibility_faq_button_hint_non_bag: እዚ መጠውቒ/Button ካብቲ ኤፕ ይወጽእን ሓድሽ ወብሳይት ይኸፍትን።
     begegnung_detail_no_last_sync_accessibility: ክሳብ ሕጂ ሲንክሮናይሰሽን የለን
     meldungen_background_error_text_android: ሓድሽ ሓበሬታ ምስዝህሉ: ካብቲ ኣፕ ወጻኢ ውን ንኽትሕበሩ ምእንታን: ነቲ ሴቲንግ ቀይርዎ።
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: ቁጽርታት
     stats_title: ድሮ ንSwisCovid ይጥቐሙሉ እዮም

--- a/dpppt-config-backend/src/main/resources/i18n/messages_tr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_tr.properties
@@ -209,7 +209,7 @@ tr:
     no_meldungen_box_link: Kendimizi bu şekilde koruruz
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Bir Kovid kodu nedir?
-    inform_detail_faq1_text: Korona virüsü testi pozitif olan kişilere Kovid kodu verilir.\n\nBu şekilde yalnızca onaylanmış vakaların uygulama üzerinden bildirilmesi garantilenir.\n\nTest sonucunuz pozitif çıktı ve 2 saat içerisinde henüz Covid kodunu almadınız mı?\nBu durumda, Corona Virüs Bilgi Hattı (Infoline) ile iletişime geçiniz:
+    inform_detail_faq1_text: Korona virüsü testi pozitif olan kişilere Kovid kodu verilir.\n\nBu şekilde yalnızca onaylanmış vakaların uygulama üzerinden bildirilmesi garantilenir.\n\nTest sonucunuz pozitif çıktı ve 4 saat içerisinde henüz Covid kodunu almadınız mı?\nBu durumda, Corona Virüs Bilgi Hattı (Infoline) ile iletişime geçiniz:
     inform_detail_faq2_title: Neler iletilir?
     inform_detail_faq2_text: Şahsi bilgileriniz değil, uygulamanızın yalnızca rastgele ID'leri iletilir. \nBu şekilde diğer SwissCovid uygulaması kullanıcıları yalnızca bir bulaşma riski olabileceğini öğenir.
     infoline_tel_number: +41 58 387 77 78
@@ -313,7 +313,7 @@ tr:
     accessibility_faq_button_hint_non_bag: Bu buton, uygulamadan çıkarak bir web sayfası açar.
     begegnung_detail_no_last_sync_accessibility: Şu ana kadar yapılmış senkronizasyon bulunmuyor
     meldungen_background_error_text_android: Uygulama açık olmadığında da bildirim alabilmek için lütfen ayarları değiştirin.
-    infoline_coronavirus_number: +41 58 463 00 00
+    infoline_coronavirus_number: +41 58 387 77 80
     tracing_setting_text_ios_14_0: Maruz Kalma Bildirimleri
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Kişi sayısı


### PR DESCRIPTION
This PR changes:
- the phone number which can be called when a user did not receive a Covidcode
- the duration from 2h to 4h