### PR TITLE
fix tel link. `tel://` -> `tel:`

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/GaenConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/GaenConfigController.java
@@ -449,7 +449,7 @@ public class GaenConfigController {
 						setText(messages.getMessage("inform_detail_faq1_text", locale));
 						setLinkTitle(messages.getMessage("infoline_coronavirus_number", locale));
 						setLinkUrl(
-								"tel://" + messages.getMessage("infoline_coronavirus_number", locale).replace(" ", ""));
+								"tel:" + messages.getMessage("infoline_coronavirus_number", locale).replace(" ", ""));
 						setIconAndroid("ic_verified_user");
 						setIconIos("ic-verified-user");
 					}


### PR DESCRIPTION
This PR fixes the protokol prefix for the telefon number, as some android devices could not handle the double slashes.