### PR TITLE
Specify which tests allow to get a CovidCode

### DIFF
--- a/dpppt-config-backend/src/main/resources/i18n/messages_bs.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_bs.properties
@@ -300,7 +300,7 @@ bs:
     accessibility_tracing_has_been_activated: Praćenje je aktivirano
     accessibility_tracing_has_been_deactivated: Praćenje je deaktivirano
     meldungen_detail_free_test_title: Moguće je besplatno testiranje
-    meldungen_detail_free_test_text: SwissCovid smernice informišu Vas o mogućnosti besplatnog testiranja na virus korona.
+    meldungen_detail_free_test_text_old: SwissCovid smernice informišu Vas o mogućnosti besplatnog testiranja na virus korona.
     activate_tracing_button: Aktiviraj praćenje
     tracing_turned_off_detailed_text: Aktivirajte praćenje kako bi aplikacija mogla da čuva kontakte i prima poruke.
     meldungen_tracing_not_active_warning: Ako je praćenje deaktivirano, ni primanje poruka neće biti moguće.
@@ -475,3 +475,4 @@ bs:
     stats_covidcodes_total_header: Ukupno
     stats_covidcodes_0to2days_header: Aktuelno
     stats_cases_rel_prev_week_popup_header: Promena u vezi prošle nedelje
+    reset_update_boarding: Resetuj update boarding

--- a/dpppt-config-backend/src/main/resources/i18n/messages_bs.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_bs.properties
@@ -209,7 +209,7 @@ bs:
     no_meldungen_box_link: Evo kako da se zaštitimo
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Šta je Covid šifra?
-    inform_detail_faq1_text: Ljudi koji su testirani pozitivno na virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.
+    inform_detail_faq1_text: Osobe pozitivno testirane na korona virus (PCR test ili antigen (brzi test) dobijaju kovid šifru.\n\nTime se obezbeđuje da samo potvrđeni slučajevi budu prijavljeni preko aplikacije.
     inform_detail_faq2_title: Šta se šalje?
     inform_detail_faq2_text: Šalju se samo privatni identifikacioni ključevi iz vaše aplikacije, a ne šalju se lični podaci.\n\nTime drugi korisnici aplikacije SwissCovid mogu da saznaju da postoji mogućnost infekcije.
     infoline_tel_number: +41 58 387 77 78
@@ -463,7 +463,7 @@ bs:
     stats_cases_rel_prev_week_description: Pokazuje promenu proseka od 7 dana upoređujući stanje od pre nedelju dana.
     stats_cases_current_label: Aktuelan razvoj
     stats_cases_current_description: Grafika pokazuje prijavljene nove infekcije poslednjih 28 dana. Time imate pregled o aktuelnom razvoju.
-    inform_detail_infobox1_text: Testirani ste pozitivno i 4 h posle još niste dobili Covid šifru?\nKontaktirajte info-liniju za Covid šifre:
+    inform_detail_infobox1_text: Pozitivno ste testirani (PCR test ili antigen brzi test) i ni posle 4 sata niste dobili kovid šifru?\nU tom slučaju kontaktirajte Infoline Coronavirus:
     inform_detail_infobox1_title: Još niste dobili Covid šifru?
     homescreen_isolation_ended_popup_title: Da li je vaša izolacija istekla?
     homescreen_isolation_ended_popup_text: Praćenje može opet da se aktivira, čim ste završili sa izolacijom.
@@ -475,4 +475,19 @@ bs:
     stats_covidcodes_total_header: Ukupno
     stats_covidcodes_0to2days_header: Aktuelno
     stats_cases_rel_prev_week_popup_header: Promena u vezi prošle nedelje
+    meldungen_positive_tested_faq2_title: Ko se obaveštava
+    meldungen_positive_tested_faq2_text: Obaveštavaju se svi kontakti u periodu vaše faze zaražavanja od {ONSET_DATE} do unosa kovid šifre, ukoliko je na osnovu distance i trajanja postojala mogućnost zaraze.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – danas
+    inform_send_thankyou_text_stop_infection_chains: Na taj način pomažete u zaustavljanju lanca zaraze.
+    inform_send_thankyou_text_onsetdate_info: Privatni ključevi vaše aplikacije poslati su za sledeći period:
+    android_inform_tracing_enabled_explanation: Prilikom unosa kovid šifre mora se aktivirati praćenje (tracing) kako bi vaši privatni ključevi mogli da se dele.
+    leitfaden_infopopup_text: Kada pritisnete "{BUTTON_TITLE}" napuštate aplikaciju i dolazite na internet stranicu SwissCovid vodiča. Pri tome se podaci poslednjeg susreta sa mogućim zaražavanjem šalju internet stranici.
+    leitfaden_infopopup_title: Informacije iz SwissCovid vodiča
+    germany_update_boarding_title: Kompatibilno sa Nemačkom
+    germany_update_boarding_text: Takođe ćete biti informisani ako ste bili u kontaktu sa osobom koja koristi nemačku aplikaciju na upozorenje na koronu i kasnije je testirana pozitivno i obrnuto. U tu svrhu su ažurirani uslovi korišćenja i izjava o zaštiti podataka.
+    germany_update_boarding_heading: SwissCovid ažuriranje
     reset_update_boarding: Resetuj update boarding
+    meldungen_detail_free_test_text: Testiranje na koronu ima smisla i preporučuje se posle 5. dana od prikazanog datuma kontakta.
+    meldungen_detail_free_test_in_x_tagen: Za {COUNT} dana
+    meldungen_detail_free_test_now: Sada
+    meldungen_detail_free_test_tomorrow: Za 1 dan

--- a/dpppt-config-backend/src/main/resources/i18n/messages_de.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_de.properties
@@ -209,7 +209,7 @@ de:
     no_meldungen_box_link: So schützen wir uns
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Was ist ein Covidcode?
-    inform_detail_faq1_text: Positiv auf das Coronavirus getestete Personen erhalten einen Covidcode.\n\nDamit wird sichergestellt, dass nur bestätigte Fälle über die App gemeldet werden.
+    inform_detail_faq1_text: Positiv auf das Coronavirus getestete Personen (PCR-Test oder Antigen-Schnelltest) erhalten einen Covidcode.\n\nDamit wird sichergestellt, dass nur bestätigte Fälle über die App gemeldet werden.
     inform_detail_faq2_title: Was wird gesendet?
     inform_detail_faq2_text: Es werden nur die privaten Schlüssel Ihrer App gesendet, keine persönlichen Daten.\n\nDamit erfahren andere SwissCovid App Nutzer, dass die Möglichkeit einer Ansteckung besteht.
     infoline_tel_number: +41 58 387 77 78
@@ -300,7 +300,7 @@ de:
     accessibility_tracing_has_been_activated: Tracing wurde aktiviert
     accessibility_tracing_has_been_deactivated: Tracing wurde deaktiviert
     meldungen_detail_free_test_title: Kostenloser Test möglich
-    meldungen_detail_free_test_text: Der SwissCovid Leitfaden informiert Sie über die Möglichkeit eines kostenlosen Coronavirus-Tests.
+    meldungen_detail_free_test_text_old: Der SwissCovid Leitfaden informiert Sie über die Möglichkeit eines kostenlosen Coronavirus-Tests.
     activate_tracing_button: Tracing aktivieren
     tracing_turned_off_detailed_text: Aktivieren Sie das Tracing, damit die App Begegnungen speichern und Meldungen empfangen kann.
     meldungen_tracing_not_active_warning: Wenn das Tracing deaktiviert ist, können auch keine Meldungen empfangen werden.
@@ -467,7 +467,7 @@ de:
     stats_cases_rel_prev_week_description: Zeigt die Veränderung des 7-Tage-Schnitts im Vergleich zum Stand von vor einer Woche.
     stats_cases_current_label: Aktuelle Entwicklung
     stats_cases_current_description: Die Grafik zeigt die gemeldeten Neuinfektionen der letzten 28 Tage. Dies gibt einen Überblick über die aktuelle Entwicklung.
-    inform_detail_infobox1_text: Sie wurden positiv getestet und haben nach 4h noch keinen Covidcode erhalten?\nDann kontaktieren Sie die Infoline Coronavirus:
+    inform_detail_infobox1_text: Sie wurden positiv getestet (PCR-Test oder Antigen-Schnelltest) und haben nach 4h noch keinen Covidcode erhalten?\nDann kontaktieren Sie die Infoline Coronavirus:
     inform_detail_infobox1_title: Noch keinen Covidcode?
     homescreen_isolation_ended_popup_title: Haben Sie Ihre Isolation beendet?
     homescreen_isolation_ended_popup_text: Das Tracing kann wieder aktiviert werden, sobald Sie die Isolation beendet haben.
@@ -479,3 +479,19 @@ de:
     stats_covidcodes_total_header: Total
     stats_covidcodes_0to2days_header: Aktuell
     stats_cases_rel_prev_week_popup_header: Veränderung zur Vorwoche
+    meldungen_positive_tested_faq2_title: Wer wird benachrichtigt?
+    meldungen_positive_tested_faq2_text: Es werden alle Kontakte im Zeitraum Ihrer Ansteckungsphase vom {ONSET_DATE} bis zur Eingabe des Covidcodes benachrichtigt, wenn auf Grund der Distanz und der Dauer das Risiko einer Ansteckung bestand.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – heute
+    inform_send_thankyou_text_stop_infection_chains: Damit helfen Sie mit, Infektionsketten zu stoppen.
+    inform_send_thankyou_text_onsetdate_info: Die privaten Schlüssel Ihrer App wurden für den folgenden Zeitraum gesendet:
+    android_inform_tracing_enabled_explanation: Beim Eingeben eines Covidcodes muss das Tracing aktiviert sein, damit Ihre privaten Schlüssel geteilt werden können.
+    leitfaden_infopopup_text: Wenn Sie "{BUTTON_TITLE}" drücken, so verlassen Sie die App und wechseln auf die Website des SwissCovid Leitfaden. Dabei werden die Daten der letzten Begegnungen von möglichen Ansteckungen der Website mitgeschickt.
+    leitfaden_infopopup_title: Information SwissCovid Leitfaden
+    germany_update_boarding_title: Kompatibel mit Deutschland
+    germany_update_boarding_text: Sie werden auch informiert, wenn Sie mit einer Person in Kontakt waren, welche die deutsche Corona-Warn-App nutzt und später positiv getestet wurde und umgekehrt. Dazu wurden die Nutzungsbedingungen und Datenschutzerklärung aktualisiert.
+    germany_update_boarding_heading: SwissCovid Update
+    reset_update_boarding: Update Boarding zurücksetzen
+    meldungen_detail_free_test_text: Ein Corona Test ist ab dem 5. Tag nach dem angezeigten Kontaktdatum sinnvoll und empfohlen.
+    meldungen_detail_free_test_in_x_tagen: In {COUNT} Tagen
+    meldungen_detail_free_test_now: Jetzt
+    meldungen_detail_free_test_tomorrow: In 1 Tag

--- a/dpppt-config-backend/src/main/resources/i18n/messages_de.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_de.properties
@@ -480,12 +480,12 @@ de:
     stats_covidcodes_0to2days_header: Aktuell
     stats_cases_rel_prev_week_popup_header: Veränderung zur Vorwoche
     meldungen_positive_tested_faq2_title: Wer wird benachrichtigt?
-    meldungen_positive_tested_faq2_text: Es werden alle Kontakte im Zeitraum Ihrer Ansteckungsphase vom {ONSET_DATE} bis zur Eingabe des Covidcodes benachrichtigt, wenn auf Grund der Distanz und der Dauer das Risiko einer Ansteckung bestand.
+    meldungen_positive_tested_faq2_text: Es werden alle Kontakte im Zeitraum Ihrer Ansteckungsphase vom {ONSET_DATE} bis zur Eingabe des Covidcodes benachrichtigt, wenn auf Grund der Distanz und der Dauer die Möglichkeit einer Ansteckung bestand. 
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – heute
     inform_send_thankyou_text_stop_infection_chains: Damit helfen Sie mit, Infektionsketten zu stoppen.
     inform_send_thankyou_text_onsetdate_info: Die privaten Schlüssel Ihrer App wurden für den folgenden Zeitraum gesendet:
     android_inform_tracing_enabled_explanation: Beim Eingeben eines Covidcodes muss das Tracing aktiviert sein, damit Ihre privaten Schlüssel geteilt werden können.
-    leitfaden_infopopup_text: Wenn Sie "{BUTTON_TITLE}" drücken, so verlassen Sie die App und wechseln auf die Website des SwissCovid Leitfaden. Dabei werden die Daten der letzten Begegnungen von möglichen Ansteckungen der Website mitgeschickt.
+    leitfaden_infopopup_text: Wenn Sie "{BUTTON_TITLE}" drücken, verlassen Sie die App und wechseln auf die Website des SwissCovid Leitfadens. Dabei werden die Daten der letzten Begegnungen von möglichen Ansteckungen der Website mitgeschickt.
     leitfaden_infopopup_title: Information SwissCovid Leitfaden
     germany_update_boarding_title: Kompatibel mit Deutschland
     germany_update_boarding_text: Sie werden auch informiert, wenn Sie mit einer Person in Kontakt waren, welche die deutsche Corona-Warn-App nutzt und später positiv getestet wurde und umgekehrt. Dazu wurden die Nutzungsbedingungen und Datenschutzerklärung aktualisiert.

--- a/dpppt-config-backend/src/main/resources/i18n/messages_en.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_en.properties
@@ -209,7 +209,7 @@ en:
     no_meldungen_box_link: Protect yourself and others
     no_meldungen_box_url: https://www.foph-coronavirus.ch
     inform_detail_faq1_title: What is a Covidcode?
-    inform_detail_faq1_text: People who have tested positive for the coronavirus receive a Covidcode. \n\nThis ensures that only confirmed cases are notified via the app.
+    inform_detail_faq1_text: People who test positive for coronavirus (with a PCR test or rapid antigen test) will receive a Covidcode.\n\nThis guarantees that only confirmed cases are reported via the app.
     inform_detail_faq2_title: What information gets sent?
     inform_detail_faq2_text: Only the private keys from your app are sent, no personal data. \n\nOther SwissCovid apps can then check if it is possible that they have been infected.
     infoline_tel_number: +41 58 387 77 78
@@ -465,7 +465,7 @@ en:
     stats_cases_rel_prev_week_description: Shows the change in the 7-day average compared with the situation a week ago.
     stats_cases_current_label: Current developments
     stats_cases_current_description: The chart shows new infections reported in the last 28 days. This gives an overview of current developments.
-    inform_detail_infobox1_text: Have you tested positive and still haven’t received a Covidcode after 4 hours?\nContact the Covidcode Infoline:
+    inform_detail_infobox1_text: Have you tested positive (PCR test or rapid antigen test) and did not receive a Covidcode after 4 hours?\nIf so, contact the Coronavirus Infoline:
     inform_detail_infobox1_title: Don’t have a Covidcode yet?
     homescreen_isolation_ended_popup_title: Have you come out of isolation?
     homescreen_isolation_ended_popup_text: Tracing can be reactivated once you have completed your period of isolation.
@@ -477,6 +477,19 @@ en:
     stats_covidcodes_total_header: Total
     stats_covidcodes_0to2days_header: Current
     stats_cases_rel_prev_week_popup_header: Change versus previous week
+    meldungen_positive_tested_faq2_title: Who will be notified?
+    meldungen_positive_tested_faq2_text: All the people you came into contact with during the infectious period from {ONSET_DATE} until you entered the Covidcode will be notified, if there is a possibility of infection due to the proximity and duration of the contact.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – today
+    inform_send_thankyou_text_stop_infection_chains: In this way you are helping break chains of infection.
+    inform_send_thankyou_text_onsetdate_info: Your app's private key was sent for the following period:
+    android_inform_tracing_enabled_explanation: When you enter a Covidcode, tracing needs to be activated so that your private key can be shared.
+    leitfaden_infopopup_text: If you press "{BUTTON_TITLE}", you leave the app and switch to the SwissCovid Guide website. The data on recent encounters with potentially infected people is sent to the website.
+    leitfaden_infopopup_title: SwissCovid Guide information
+    germany_update_boarding_title: Compatible with Germany
+    germany_update_boarding_text: You will also be notified if you have been in contact with someone who uses the German Corona-Warn-App and later tests positive, and vice versa. The terms of use and data protection statement have been updated accordingly.
+    germany_update_boarding_heading: SwissCovid update
     reset_update_boarding: Reset update boarding
+    meldungen_detail_free_test_text: A coronavirus test is advisable and recommended from the 5th day after the displayed contact date.
     meldungen_detail_free_test_in_x_tagen: In {COUNT} days
     meldungen_detail_free_test_now: Now
+    meldungen_detail_free_test_tomorrow: In 1 day

--- a/dpppt-config-backend/src/main/resources/i18n/messages_en.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_en.properties
@@ -300,7 +300,7 @@ en:
     accessibility_tracing_has_been_activated: Tracing has been activated
     accessibility_tracing_has_been_deactivated: Tracing has been deactivated
     meldungen_detail_free_test_title: Test available free of charge
-    meldungen_detail_free_test_text: The SwissCovid Guide has information about the possibility of a free coronavirus test.
+    meldungen_detail_free_test_text_old: The SwissCovid Guide has information about the possibility of a free coronavirus test.
     activate_tracing_button: Activate proximity tracing
     tracing_turned_off_detailed_text: Enable tracing so the app can save encounters and receive reports
     meldungen_tracing_not_active_warning: If tracing is disabled, you cannot receive any reports.
@@ -477,3 +477,6 @@ en:
     stats_covidcodes_total_header: Total
     stats_covidcodes_0to2days_header: Current
     stats_cases_rel_prev_week_popup_header: Change versus previous week
+    reset_update_boarding: Reset update boarding
+    meldungen_detail_free_test_in_x_tagen: In {COUNT} days
+    meldungen_detail_free_test_now: Now

--- a/dpppt-config-backend/src/main/resources/i18n/messages_es.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_es.properties
@@ -300,7 +300,7 @@ es:
     accessibility_tracing_has_been_activated: Se ha activado el rastreo
     accessibility_tracing_has_been_deactivated: Se ha desactivado el rastreo
     meldungen_detail_free_test_title: Posibilidad de hacer un test gratuito
-    meldungen_detail_free_test_text: La guía SwissCovid le informa sobre la posibilidad de hacer un test de coronavirus gratuito.
+    meldungen_detail_free_test_text_old: La guía SwissCovid le informa sobre la posibilidad de hacer un test de coronavirus gratuito.
     activate_tracing_button: Activar el rastreo
     tracing_turned_off_detailed_text: Active el rastreo para permitir que la app guarde los contactos y reciba notificaciones.
     meldungen_tracing_not_active_warning: No es posible recibir notificaciones si el rastreo está desactivado.
@@ -476,3 +476,4 @@ es:
     stats_covidcodes_total_header: Total
     stats_covidcodes_0to2days_header: Actual
     stats_cases_rel_prev_week_popup_header: Cambio con respecto a la semana previa
+    reset_update_boarding: Reiniciar update boarding

--- a/dpppt-config-backend/src/main/resources/i18n/messages_es.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_es.properties
@@ -209,7 +209,7 @@ es:
     no_meldungen_box_link: Así nos protegemos
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: ¿Qué es el código Covid?
-    inform_detail_faq1_text: Las personas que han dado positivo en el test del  coronavirus reciben un código Covid. \n\nAsí se garantiza que la aplicación solo informe de los casos confirmados.
+    inform_detail_faq1_text: Las personas que han dado positivo al coronavirus (test PCR o test rápido de antígenos) reciben un código Covid.\n\nAsí queda garantizado que solo se notifiquen casos confirmados a través de la aplicación.
     inform_detail_faq2_title: ¿Qué es lo que se envía?
     inform_detail_faq2_text: Solamente se envían las claves privadas de la aplicación y no los datos personales. \n\nDe esta forma, se informa a otros usuarios de la aplicación SwissCovid de que existe la posibilidad de contagio.
     infoline_tel_number: +41 58 387 77 78
@@ -464,7 +464,7 @@ es:
     stats_cases_rel_prev_week_description: Muestra el cambio del promedio de 7 días en comparación con la semana anterior.
     stats_cases_current_label: Evolución actual
     stats_cases_current_description: El gráfico muestra los nuevos contagios notificados en los últimos 28 días. Así, se obtiene una panorámica de la evolución actual.
-    inform_detail_infobox1_text: ¿Ha dado usted positivo en el test y no ha obtenido el código Covid después de 4 horas? En este caso, llame a la Infoline:
+    inform_detail_infobox1_text: ¿Ha dado usted positivo (test PCR o test rápido de antígenos) y no ha recibido el código Covid después de 4 horas?\nContacte con la Infoline del coronavirus:
     inform_detail_infobox1_title: ¿Aún no ha recibido el código Covid?
     homescreen_isolation_ended_popup_title: ¿Ha terminado el aislamiento?
     homescreen_isolation_ended_popup_text: El rastreo puede ser activado de nuevo tan pronto como haya terminado el aislamiento.
@@ -476,4 +476,19 @@ es:
     stats_covidcodes_total_header: Total
     stats_covidcodes_0to2days_header: Actual
     stats_cases_rel_prev_week_popup_header: Cambio con respecto a la semana previa
+    meldungen_positive_tested_faq2_title: ¿Quién será notificado?
+    meldungen_positive_tested_faq2_text: Se notificará a todos los contactos establecidos durante la fase de contagio desde el {ONSET_DATE} hasta la introducción del código Covid si un contagio es probable a raíz de la distancia y la duración.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – hoy
+    inform_send_thankyou_text_stop_infection_chains: Así está contribuyendo a interrumpir las cadenas de contagio.
+    inform_send_thankyou_text_onsetdate_info: Las claves privadas de su aplicación se han enviado para el periodo siguiente:
+    android_inform_tracing_enabled_explanation: El rastreo debe estar activado al introducir el código Covid para permitir el intercambio de las claves privadas.
+    leitfaden_infopopup_text: Al pulsar "{BUTTON_TITLE}", abandonará la app para ir a la página web de la Guía SwissCovid. En este proceso, también se transmitirán a la página web los datos de los últimos contactos en los que posiblemente haya habido contagio.
+    leitfaden_infopopup_title: Información sobre la Guía SwissCovid
+    germany_update_boarding_title: Compatible con Alemania
+    germany_update_boarding_text: Será usted informado en caso de haber tenido contacto con una persona que use la aplicación alemana Corona-Warn-App y que haya dado positivo y viceversa. Para este fin, se han actualizado las condiciones de uso y la política de privacidad.
+    germany_update_boarding_heading: Actualización SwissCovid
     reset_update_boarding: Reiniciar update boarding
+    meldungen_detail_free_test_text: Es conveniente y recomendable hacer un test de Covid-19 transcurridos 5 días desde la fecha del contacto indicada.
+    meldungen_detail_free_test_in_x_tagen: En {COUNT} días
+    meldungen_detail_free_test_now: Ahora
+    meldungen_detail_free_test_tomorrow: En 1 día

--- a/dpppt-config-backend/src/main/resources/i18n/messages_fr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_fr.properties
@@ -300,7 +300,7 @@ fr:
     accessibility_tracing_has_been_activated: Traçage activé
     accessibility_tracing_has_been_deactivated: Traçage désactivé
     meldungen_detail_free_test_title: Test gratuit
-    meldungen_detail_free_test_text: Le guide SwissCovid vous informe sur la possibilité de vous faire tester gratuitement au coronavirus. 
+    meldungen_detail_free_test_text_old: Le guide SwissCovid vous informe sur la possibilité de vous faire tester gratuitement au coronavirus. 
     activate_tracing_button: Activer le traçage
     tracing_turned_off_detailed_text: Activez le traçage pour que l'application puisse enregistrer les rencontres et recevoir des messages.
     meldungen_tracing_not_active_warning: Si le traçage est désactivé, vous ne pouvez recevoir aucun message.
@@ -477,3 +477,4 @@ fr:
     stats_covidcodes_total_header: Total
     stats_covidcodes_0to2days_header: Actuellement
     stats_cases_rel_prev_week_popup_header: Changemenent depuis la semaine passée
+    reset_update_boarding: Réinitialiser l'intégration

--- a/dpppt-config-backend/src/main/resources/i18n/messages_fr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_fr.properties
@@ -209,7 +209,7 @@ fr:
     no_meldungen_box_link: Voici comment nous protéger
     no_meldungen_box_url: https://ofsp-coronavirus.ch/
     inform_detail_faq1_title: Qu'est-ce qu'un code COVID ?
-    inform_detail_faq1_text: Un code COVID est attribué aux personnes testées positives au coronavirus.\n\nCela permet d'assurer que seuls les cas confirmés sont signalés via l'application.
+    inform_detail_faq1_text: Les personnes testées positives au coronavirus (test PCR ou test rapide antigénique) reçoivent un code COVID.\n\nCeci permet de garantir que seuls les cas confirmés sont déclarés dans l'application.
     inform_detail_faq2_title: Qu'est-ce qui est envoyé ?
     inform_detail_faq2_text: Seules les clés privées de votre application sont envoyées, aucune donnée personnelle.\n\nAinsi, d'autres utilisateurs de l'application SwissCovid apprennent qu'ils ont peut-être été infectés.
     infoline_tel_number: +41 58 387 77 78
@@ -465,7 +465,7 @@ fr:
     stats_cases_rel_prev_week_description: Indique le changement de la moyenne pendant 7 jours par rapport à la semaine passée.
     stats_cases_current_label: Évolution actuelle
     stats_cases_current_description: Le graphique indique les nouvelles infections déclarées pendant les 28 derniers jours pour donner un aperçu de l'évolution actuelle.
-    inform_detail_infobox1_text: Vous avez été testé positif mais n'avez pas encore reçu de code COVID 4 heures plus tard ? Contactez l'infoline:
+    inform_detail_infobox1_text: Vous avez été testé positif (test PCR ou test rapide antigénique) mais vous n'avez pas encore reçu de code COVID après 4 heures ?\nContactez l'infoline coronavirus :
     inform_detail_infobox1_title: Pas encore de code COVID ?
     homescreen_isolation_ended_popup_title: Avez-vous terminé votre isolement ?
     homescreen_isolation_ended_popup_text: Le traçage peut être réactivé dès que votre isolement prend fin.
@@ -477,4 +477,19 @@ fr:
     stats_covidcodes_total_header: Total
     stats_covidcodes_0to2days_header: Actuellement
     stats_cases_rel_prev_week_popup_header: Changemenent depuis la semaine passée
+    meldungen_positive_tested_faq2_title: Qui est averti ?
+    meldungen_positive_tested_faq2_text: Tous les contacts recensés pendant votre phase contagieuse du {ONSET_DATE} jusqu'à la saisie de votre code COVID sont avertis en cas de risque d'infection dû à la distance et à la durée du contact.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – aujourd'hui
+    inform_send_thankyou_text_stop_infection_chains: Merci de nous aider à briser les chaînes d'infection.
+    inform_send_thankyou_text_onsetdate_info: Les clés privées de votre application ont été envoyées pour la période suivante :
+    android_inform_tracing_enabled_explanation: Le traçage doit être activé lors de la saisie d'un code COVID, afin que les clés privées puissent être envoyées.
+    leitfaden_infopopup_text: En cliquant sur "{BUTTON_TITLE}", vous quitterez l'application et serez redirigé sur le site du guide SwissCovid. Les dates de vos derniers contacts avec des personnes potentiellement infectées seront alors transmises au site.
+    leitfaden_infopopup_title: Information Guide SwissCovid
+    germany_update_boarding_title: Compatible avec l'Allemagne
+    germany_update_boarding_text: Vous serez également alerté si vous avez été en contact avec une personne qui utilise l'application allemande Corona-Warn-App et qui a été testée positive (et inversément). Les conditions d'utilisation et la déclaration concernant la protection des données ont été mises à jour.
+    germany_update_boarding_heading: Mise à jour SwissCovid
     reset_update_boarding: Réinitialiser l'intégration
+    meldungen_detail_free_test_text: Un test est utile et recommandé à partir du 5e jour suivant la date de contact indiquée.
+    meldungen_detail_free_test_in_x_tagen: Dans {COUNT} jours
+    meldungen_detail_free_test_now: Maintenant
+    meldungen_detail_free_test_tomorrow: Dans 1 jour

--- a/dpppt-config-backend/src/main/resources/i18n/messages_hr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_hr.properties
@@ -300,7 +300,7 @@ hr:
     accessibility_tracing_has_been_activated: Praćenje je aktivirano
     accessibility_tracing_has_been_deactivated: Praćenje je deaktivirano
     meldungen_detail_free_test_title: Moguće je besplatno testiranje
-    meldungen_detail_free_test_text: SwissCovid smernice informišu Vas o mogućnosti besplatnog testiranja na virus korona.
+    meldungen_detail_free_test_text_old: SwissCovid smernice informišu Vas o mogućnosti besplatnog testiranja na virus korona.
     activate_tracing_button: Aktiviraj praćenje
     tracing_turned_off_detailed_text: Aktivirajte praćenje kako bi aplikacija mogla da čuva kontakte i prima poruke.
     meldungen_tracing_not_active_warning: Ako je praćenje deaktivirano, ni primanje poruka neće biti moguće.
@@ -475,3 +475,4 @@ hr:
     stats_covidcodes_total_header: Ukupno
     stats_covidcodes_0to2days_header: Aktuelno
     stats_cases_rel_prev_week_popup_header: Promena u vezi prošle nedelje
+    reset_update_boarding: Resetuj update boarding

--- a/dpppt-config-backend/src/main/resources/i18n/messages_hr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_hr.properties
@@ -209,7 +209,7 @@ hr:
     no_meldungen_box_link: Evo kako da se zaštitimo
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Šta je Covid šifra?
-    inform_detail_faq1_text: Ljudi koji su testirani pozitivno na virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.
+    inform_detail_faq1_text: Osobe pozitivno testirane na korona virus (PCR test ili antigen (brzi test) dobijaju kovid šifru.\n\nTime se obezbeđuje da samo potvrđeni slučajevi budu prijavljeni preko aplikacije.
     inform_detail_faq2_title: Šta se šalje?
     inform_detail_faq2_text: Šalju se samo privatni identifikacioni ključevi iz vaše aplikacije, a ne šalju se lični podaci.\n\nTime drugi korisnici aplikacije SwissCovid mogu da saznaju da postoji mogućnost infekcije.
     infoline_tel_number: +41 58 387 77 78
@@ -463,7 +463,7 @@ hr:
     stats_cases_rel_prev_week_description: Pokazuje promenu proseka od 7 dana upoređujući stanje od pre nedelju dana.
     stats_cases_current_label: Aktuelan razvoj
     stats_cases_current_description: Grafika pokazuje prijavljene nove infekcije poslednjih 28 dana. Time imate pregled o aktuelnom razvoju.
-    inform_detail_infobox1_text: Testirani ste pozitivno i 4 h posle još niste dobili Covid šifru?\nKontaktirajte info-liniju za Covid šifre:
+    inform_detail_infobox1_text: Pozitivno ste testirani (PCR test ili antigen brzi test) i ni posle 4 sata niste dobili kovid šifru?\nU tom slučaju kontaktirajte Infoline Coronavirus:
     inform_detail_infobox1_title: Još niste dobili Covid šifru?
     homescreen_isolation_ended_popup_title: Da li je vaša izolacija istekla?
     homescreen_isolation_ended_popup_text: Praćenje može opet da se aktivira, čim ste završili sa izolacijom.
@@ -475,4 +475,19 @@ hr:
     stats_covidcodes_total_header: Ukupno
     stats_covidcodes_0to2days_header: Aktuelno
     stats_cases_rel_prev_week_popup_header: Promena u vezi prošle nedelje
+    meldungen_positive_tested_faq2_title: Ko se obaveštava
+    meldungen_positive_tested_faq2_text: Obaveštavaju se svi kontakti u periodu vaše faze zaražavanja od {ONSET_DATE} do unosa kovid šifre, ukoliko je na osnovu distance i trajanja postojala mogućnost zaraze.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – danas
+    inform_send_thankyou_text_stop_infection_chains: Na taj način pomažete u zaustavljanju lanca zaraze.
+    inform_send_thankyou_text_onsetdate_info: Privatni ključevi vaše aplikacije poslati su za sledeći period:
+    android_inform_tracing_enabled_explanation: Prilikom unosa kovid šifre mora se aktivirati praćenje (tracing) kako bi vaši privatni ključevi mogli da se dele.
+    leitfaden_infopopup_text: Kada pritisnete "{BUTTON_TITLE}" napuštate aplikaciju i dolazite na internet stranicu SwissCovid vodiča. Pri tome se podaci poslednjeg susreta sa mogućim zaražavanjem šalju internet stranici.
+    leitfaden_infopopup_title: Informacije iz SwissCovid vodiča
+    germany_update_boarding_title: Kompatibilno sa Nemačkom
+    germany_update_boarding_text: Takođe ćete biti informisani ako ste bili u kontaktu sa osobom koja koristi nemačku aplikaciju na upozorenje na koronu i kasnije je testirana pozitivno i obrnuto. U tu svrhu su ažurirani uslovi korišćenja i izjava o zaštiti podataka.
+    germany_update_boarding_heading: SwissCovid ažuriranje
     reset_update_boarding: Resetuj update boarding
+    meldungen_detail_free_test_text: Testiranje na koronu ima smisla i preporučuje se posle 5. dana od prikazanog datuma kontakta.
+    meldungen_detail_free_test_in_x_tagen: Za {COUNT} dana
+    meldungen_detail_free_test_now: Sada
+    meldungen_detail_free_test_tomorrow: Za 1 dan

--- a/dpppt-config-backend/src/main/resources/i18n/messages_it.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_it.properties
@@ -209,7 +209,7 @@ it:
     no_meldungen_box_link: Così ci proteggiamo
     no_meldungen_box_url: https://www.ufsp-coronavirus.ch
     inform_detail_faq1_title: Cos'è un codice Covid?
-    inform_detail_faq1_text: Le persone che sono risultate positive al test del coronavirus ricevono un codice Covid.\n\nIn questo modo si garantisce che l'app segnali soltanto i casi confermati.
+    inform_detail_faq1_text: Le persone che sono risultate positive al test del coronavirus (PCR o antigenico rapido) ricevono un codice Covid.\n\nIn questo modo si garantisce che l'app segnali soltanto i casi confermati.
     inform_detail_faq2_title: Che cosa viene inviato?
     inform_detail_faq2_text: Vengono inviate soltanto le chiavi private della tua app, non i tuoi dati personali.\n\nIn questo modo gli altri utenti dell'app SwissCovid vengono a sapere che vi è la possibilità di un contagio.
     infoline_tel_number: +41 58 387 77 78
@@ -465,7 +465,7 @@ it:
     stats_cases_rel_prev_week_description: Mostra la differenza tra la media di 7 giorni attuale e quella della settimana precedente.
     stats_cases_current_label: Sviluppo attuale
     stats_cases_current_description: Il grafico mostra le nuove infezioni dichiarate negli ultimi 28 giorni. Ciò fornisce una panoramica sul sviluppo attuale.
-    inform_detail_infobox1_text: Sei risultato positivo al test e dopo quattro ore non hai ancora ricevuto un codice Covid?\nAllora contatta la Infoline codice Covid:
+    inform_detail_infobox1_text: Sei risultato positivo al test (PCR o antigenico rapido) e dopo quattro ore non hai ancora ricevuto un codice Covid?\nContatta la Infoline coronavirus:
     inform_detail_infobox1_title: Non hai ancora un codice Covid?
     homescreen_isolation_ended_popup_title: Avete concluso l'isolamento?
     homescreen_isolation_ended_popup_text: Il tracciamento può essere riattivato non appena l'isolamento è concluso.
@@ -477,4 +477,19 @@ it:
     stats_covidcodes_total_header: Totale
     stats_covidcodes_0to2days_header: Attuale
     stats_cases_rel_prev_week_popup_header: Cambio rispetto alla settimana precedente
+    meldungen_positive_tested_faq2_title: Chi viene avvertito?
+    meldungen_positive_tested_faq2_text: Vengono avvertiti tutti i contatti nel periodo della tua fase contagiosa dal {ONSET_DATE} fino all'immissione del codice Covid, se in base alla distanza e alla durata vi è stata la possibilità di un contagio.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – oggi
+    inform_send_thankyou_text_stop_infection_chains: Così contribuisci a fermare le catene di infezione.
+    inform_send_thankyou_text_onsetdate_info: Le chiavi private della tua app sono state inviate per il seguente periodo:
+    android_inform_tracing_enabled_explanation: Al momento dell'immissione di un codice Covid il tracciamento deve essere attivato affinché sia possibile condividere le tue chiavi private.
+    leitfaden_infopopup_text: Premendo il pulsante "{BUTTON_TITLE}" si esce dall'app e si passa al sito web della guida SwissCovid. I dati degli ultimi incontri con persone potenzialmente infette vengono trasmessi al sito web.
+    leitfaden_infopopup_title: Informazioni sulla guida SwissCovid
+    germany_update_boarding_title: Compatibile con la Germania
+    germany_update_boarding_text: Vieni informato anche se sei stato in contatto con una persona che utilizza l'app tedesca Corona-Warn-App e successivamente è risultata positiva al test e viceversa. A tale scopo sono state aggiornate le condizioni di utilizzo e l'informativa sulla protezione dei dati.
+    germany_update_boarding_heading: Aggiornamento SwissCovid
     reset_update_boarding: Reimposta update boarding
+    meldungen_detail_free_test_text: Un test del coronavirus è opportuno e raccomandato a partire dal 5° giorno dopo la data di contatto indicata.
+    meldungen_detail_free_test_in_x_tagen: Fra {COUNT} giorni
+    meldungen_detail_free_test_now: Ora
+    meldungen_detail_free_test_tomorrow: Fra 1 giorno

--- a/dpppt-config-backend/src/main/resources/i18n/messages_it.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_it.properties
@@ -300,7 +300,7 @@ it:
     accessibility_tracing_has_been_activated: Tracciamento attivato
     accessibility_tracing_has_been_deactivated: Tracciamento disattivato
     meldungen_detail_free_test_title: Possibilità di sottoporsi gratuitamente al test
-    meldungen_detail_free_test_text: La guida SwissCovid ti informa sulla possibilità di fare gratis il test del coronavirus.
+    meldungen_detail_free_test_text_old: La guida SwissCovid ti informa sulla possibilità di fare gratis il test del coronavirus.
     activate_tracing_button: Attivare il tracciamento
     tracing_turned_off_detailed_text: Attiva il tracciamento affinché l'app possa salvare gli incontri e ricevere le segnalazioni.
     meldungen_tracing_not_active_warning: Se il tracciamento è disattivato, non puoi ricevere alcuna segnalazione.
@@ -477,3 +477,4 @@ it:
     stats_covidcodes_total_header: Totale
     stats_covidcodes_0to2days_header: Attuale
     stats_cases_rel_prev_week_popup_header: Cambio rispetto alla settimana precedente
+    reset_update_boarding: Reimposta update boarding

--- a/dpppt-config-backend/src/main/resources/i18n/messages_pt.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_pt.properties
@@ -209,7 +209,7 @@ pt:
     no_meldungen_box_link: Como nos protegemos
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: O que é um código COVID?
-    inform_detail_faq1_text: As pessoas que testaram positivo para o coronavírus recebem um código COVID.\n\nIsto assegura que só os casos confirmados são assinalados na app.
+    inform_detail_faq1_text: Pessoas com teste de coronavírus positivo (teste PCR ou teste rápido de antigénio) recebem um código Covid.\n\nIsso assegura que só casos confirmados sejam comunicados através do aplicativo.
     inform_detail_faq2_title: Que dados são enviados?
     inform_detail_faq2_text: Só são enviadas as chaves privadas do seu app e nunca dados pessoais.\n\nDesta forma, outros utilizadores do app SwissCovid ficam a saber que existe a possibilidade de um contágio.
     infoline_tel_number: +41 58 387 77 78
@@ -465,7 +465,7 @@ pt:
     stats_cases_rel_prev_week_description: É a variação da média dos 7 dias em comparação com o estado de há uma semana.
     stats_cases_current_label: Evolução atual
     stats_cases_current_description: O gráfico mostra as novas infeções registadas nos últimos 28 dias, dando um panorama da evolução atual.
-    inform_detail_infobox1_text: Você foi testado positivo e ainda não recebeu um código COVID após 4 horas? Nesse caso contacte a linha informativa do código COVID:
+    inform_detail_infobox1_text: Foi testado positivo (teste PCR ou teste rápido de antigénio) e ainda não recebeu um código Covid depois de 4 hs?\nContacte a linha de informação coronavírus:
     inform_detail_infobox1_title: Ainda não recebeu um código COVID?
     homescreen_isolation_ended_popup_title: Já terminou o isolamento?
     homescreen_isolation_ended_popup_text: O rastreamento pode ser reativado logo que termine o isolamento.
@@ -477,3 +477,18 @@ pt:
     stats_covidcodes_total_header: Total
     stats_covidcodes_0to2days_header: Atual
     stats_cases_rel_prev_week_popup_header: Variação em relação à semana anterior
+    meldungen_positive_tested_faq2_title: Quem vai ser informado?
+    meldungen_positive_tested_faq2_text: No período da sua fase contagiosa de {ONSET_DATE} até à introdução do código Covid, todos os contactos são informados, se houver a possibilidade de infecção devido à distância e à duração.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – hoje
+    inform_send_thankyou_text_stop_infection_chains: Com isso, você ajuda a parar as cadeias de infecção.
+    inform_send_thankyou_text_onsetdate_info: Os códigos privados do seu aplicativo foram enviados para o seguinte período:
+    android_inform_tracing_enabled_explanation: Ao introduzir um código Covid, o rastreamento deve estar ativado para que seja possível compartilhar os seus códigos privados.
+    leitfaden_infopopup_text: Ao premir "{BUTTON_TITLE}" você sai do aplicativo e vai para o website do Guia SwissCovid. Nisso, os dados dos últimos encontros com possibilidade de infecção do website também são enviados.
+    leitfaden_infopopup_title: Informação Guia SwissCovid
+    germany_update_boarding_title: Compatível com a Alemanha
+    germany_update_boarding_text: Você também vai ser informado, se esteve em contacto com uma pessoa que usa o aplicativo de advertência corona alemão e, mais tarde, teve um resultado positivo no teste e vice-versa. Para tal, as condições de utilização e a política de privacidade foram atualizadas.
+    germany_update_boarding_heading: Atualização SwissCovid
+    meldungen_detail_free_test_text: Um teste de corona é útil e recomendado a partir de 5 dias após a data de contacto indicada.
+    meldungen_detail_free_test_in_x_tagen: Em {COUNT} dias
+    meldungen_detail_free_test_now: Agora
+    meldungen_detail_free_test_tomorrow: Em 1 dia

--- a/dpppt-config-backend/src/main/resources/i18n/messages_pt.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_pt.properties
@@ -300,7 +300,7 @@ pt:
     accessibility_tracing_has_been_activated: Foi ativado o rastreamento
     accessibility_tracing_has_been_deactivated: Foi desativado o rastreamento
     meldungen_detail_free_test_title: Possibilidade de teste gratuito
-    meldungen_detail_free_test_text: O guia da SwissCovid informa-o sobre a possibilidade de um teste gratuito ao coronavírus.
+    meldungen_detail_free_test_text_old: O guia da SwissCovid informa-o sobre a possibilidade de um teste gratuito ao coronavírus.
     activate_tracing_button: Ativar o rastreamento
     tracing_turned_off_detailed_text: Ative o rastreamento para que a app possa armazenar contactos e receber notificações.
     meldungen_tracing_not_active_warning: Se o rastreamento estiver desativado, a app também não pode receber notificações.

--- a/dpppt-config-backend/src/main/resources/i18n/messages_rm.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_rm.properties
@@ -209,7 +209,7 @@ rm:
     no_meldungen_box_link: Uschia ans protegin nus
     no_meldungen_box_url: https://check.bag-coronavirus.ch
     inform_detail_faq1_title: Tge è in code covid?
-    inform_detail_faq1_text: Persunas ch’èn vegnidas testadas en moda positiva sin il coronavirus survegnan in code covid.\n \nUschia vegni garantì che mo cas confermads vegnan avisads via l'app.
+    inform_detail_faq1_text: Persunas cun in test positiv sin il coronavirus (test da PCR u test svelt d'antigens) retschaivan in code covid.\n\nUschia vegn garantì ch'i vegnian annunziads sur l'app mo ils cas confermads.
     inform_detail_faq2_title: Tge vegn tramess?
     inform_detail_faq2_text: I vegnan tramessas mo las clavs privatas da Vossa app, naginas datas persunalas.\n\nUschia vegnan autras utilisadras ed auters utilisaders da l'app SwissCovid a savair ch'ina infecziun è pussaivla.
     infoline_tel_number: +41 58 387 77 78
@@ -464,7 +464,7 @@ rm:
     stats_cases_rel_prev_week_description: Mussa la midada da la media da 7 dis en cumparegliaziun cun il stadi d'avant in'emna.
     stats_cases_current_label: Svilup actual
     stats_cases_current_description: La grafica mussa las infecziuns novas annunziadas dals ultims 28 dis. Quai dat ina survista dal svilup actual.
-    inform_detail_infobox1_text: Voss test è positiv e Vus n'avais suenter 4 uras anc adina betg retschavì in code covid? Alura contactai la infoline code covid:
+    inform_detail_infobox1_text: Vus avais in test positiv (test da PCR u test svelt d'antigens) e n'avais suenter 4 uras anc betg retschavì in code covid?\nAlura contactai la Infoline coronavirus:
     inform_detail_infobox1_title: Anc nagin code covid?
     homescreen_isolation_ended_popup_title: Avais Vus terminà Vossa isolaziun?
     homescreen_isolation_ended_popup_text: Il tracing po puspè vegnir activà, uschespert che Vus avais terminà l'isolaziun.
@@ -476,4 +476,19 @@ rm:
     stats_covidcodes_total_header: total
     stats_covidcodes_0to2days_header: actual
     stats_cases_rel_prev_week_popup_header: Midada envers l'emna precedenta
+    meldungen_positive_tested_faq2_title: Tgi vegn infurmà?
+    meldungen_positive_tested_faq2_text: I vegnan infurmads tut ils contacts durant il spazi da temp da Vossa fasa d'infecziun dals {ONSET_DATE} fin a l'endataziun dal code covid, sch'i era pussaivel da s'infectar sin basa da la distanza e da la durada.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – oz
+    inform_send_thankyou_text_stop_infection_chains: Uschia gidais Vus a franar las chadainas da transmissiun.
+    inform_send_thankyou_text_onsetdate_info: Las clavs privatas da Vossa app èn vegnidas tramessas per il suandant spazi da temp:
+    android_inform_tracing_enabled_explanation: Per che Vossas clavs privatas possian vegnir cundivididas sto il tracing esser activà cun endatar in code covid.
+    leitfaden_infopopup_text: Sche Vus schmatgais sin "{BUTTON_TITLE}", bandunais Vus l'app e midais a la pagina d'internet dal mussavia SwissCovid. Uschia vegnan tramessas a la pagina d'internet er las datas dals ultims inscunters d'eventualas infecziuns.
+    leitfaden_infopopup_title: Infurmaziun mussavia SwissCovid
+    germany_update_boarding_title: Cumpatibel cun la Germania
+    germany_update_boarding_text: Vus vegnis er infurmada resp. infurmà, sche Vus avais gì contact cun ina persuna che fa diever da l'app d'avertiment da corona tudestga e che ha gì pli tard in test positiv e viceversa. Perquai èn vegnidas actualisadas las cundiziuns d'utilisaziun e la decleraziun davart la protecziun da datas.
+    germany_update_boarding_heading: Update SwissCovid
     reset_update_boarding: Redefinir update boarding
+    meldungen_detail_free_test_text: In test da corona è raschunaivel e vegn recumandà a partir dal tschintgavel di suenter la data da contact inditgada.
+    meldungen_detail_free_test_in_x_tagen: En {COUNT} dis
+    meldungen_detail_free_test_now: Ussa
+    meldungen_detail_free_test_tomorrow: En 1 di

--- a/dpppt-config-backend/src/main/resources/i18n/messages_rm.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_rm.properties
@@ -19,8 +19,8 @@ rm:
     unexpected_error_title: Igl è capità in sbagl nunspetgà.
     bluetooth_turned_off: L'app na funcziuna betg, perquai che bluetooth n'è betg activà.
     bluetooth_permission_turned_off: L'app na funcziuna betg, perquai che Vus n’avais betg dà l'autorisaziun bluetooth.
-    NSBluetoothPeripheralUsageDescription: Inscunters vegnan identifitgadas via bluetooth, economisant l'energia.
-    NSBluetoothAlwaysUsageDescription: Inscunters vegnan identifitgadas via bluetooth, economisant l'energia.
+    NSBluetoothPeripheralUsageDescription: Inscunters vegnan identifitgads via bluetooth, economisant l'energia.
+    NSBluetoothAlwaysUsageDescription: Inscunters vegnan identifitgads via bluetooth, economisant l'energia.
     inform_code_title: Endatar il code covid
     inform_code_text: Endatai il code covid che Vus avais retschavì.
     inform_code_no_code: Duvrais Vus agid?
@@ -34,7 +34,7 @@ rm:
     meldungen_meldung_title: Eventuala infecziun
     meldungen_meldung_text: Ina infecziun è pussaivla.
     tracing_active_title: App activa
-    tracing_active_text: Inscunters vegnan arcunadas en moda anonima
+    tracing_active_text: Inscunters vegnan arcunads en moda anonima
     android_tracing_error_title: Tracing inactiv
     android_foreground_service_notification_errors: App na po actualmain betg funcziunar correctamain:
     preview_warning_title: Prevista versiun
@@ -55,7 +55,7 @@ rm:
     debug_sdk_state_boolean_false: na
     debug_sdk_button_reset: Redefinir SDK
     tab_tracing_title: Tracing
-    whattodo_title_symptoms: Sintoms da malsogna
+    whattodo_title_symptoms: sintoms da malsogna
     whattodo_subtitle_symptoms: Tge far en cas da…
     whattodo_title_positivetest: resultat dal test positiv
     whattodo_subtitle_positivetest: Tge far en cas d'in…
@@ -300,7 +300,7 @@ rm:
     accessibility_tracing_has_been_activated: Tracing è vegnì activà
     accessibility_tracing_has_been_deactivated: Tracing è vegnì deactivà
     meldungen_detail_free_test_title: Pussaivel da far in test gratuit
-    meldungen_detail_free_test_text: Il mussavia SwissCovid As infurmescha davart la pussaivladad da far in test dal coronavirus gratuit.
+    meldungen_detail_free_test_text_old: Il mussavia SwissCovid As infurmescha davart la pussaivladad da far in test dal coronavirus gratuit.
     activate_tracing_button: Activar tracing
     tracing_turned_off_detailed_text: Activai il tracing per che l'app possia arcunar inscunters e retschaiver avis.
     meldungen_tracing_not_active_warning: Sch'il tracing è deactivà, na pon er vegnidas retschavids nagins avis.
@@ -476,3 +476,4 @@ rm:
     stats_covidcodes_total_header: total
     stats_covidcodes_0to2days_header: actual
     stats_cases_rel_prev_week_popup_header: Midada envers l'emna precedenta
+    reset_update_boarding: Redefinir update boarding

--- a/dpppt-config-backend/src/main/resources/i18n/messages_sq.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_sq.properties
@@ -209,7 +209,7 @@ sq:
     no_meldungen_box_link: Kështu mbrohemi ne
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Çfarë është një kod Covid?
-    inform_detail_faq1_text: Personat që kanë rezultuar pozitivë me koronavirusin marrin një kod Covid.\n\nNë këtë mënyrë sigurohet që nga aplikacioni të sinjalizohen vetëm rastet e konfirmuara.
+    inform_detail_faq1_text: Njerëzit që kanë rezultuar pozitivë për koronavirusin (test PCR ose test i shpejtë i antigjenit) marrin një kod Covid.\n\nKjo siguron se vetëm rastet e konfirmuara raportohen përmes aplikacionit.
     inform_detail_faq2_title: Çfarë dërgohet?
     inform_detail_faq2_text: Dërgohen vetëm kodet e identifikimit të aplikacionit tuaj, asnjë e dhënë personale.\n\nNë këtë mënyrë mësoni përdoruesit e tjerë të alikacionit SwissCovid, të cilët mundësisht janë infektuar.
     infoline_tel_number: +41 58 387 77 78
@@ -464,7 +464,7 @@ sq:
     stats_cases_rel_prev_week_description: Tregon ndryshimin në mesataren 7-ditore në krahasim me një javë më parë.
     stats_cases_current_label: Raste aktuale
     stats_cases_current_description: Grafiku tregon infeksionet e reja të raportuara gjatë 28 ditëve të fundit. Kjo jep një pasqyrë të rasteve aktuale.
-    inform_detail_infobox1_text: Keni rezultuar pozitiv në testim dhe pas 4 orësh nuk keni marrë ende asnjë kod Covid? Atëherë kontaktoni linjën e informacionit për kodin Covid:
+    inform_detail_infobox1_text: A keni testuar pozitiv (nga test PCR ose test i shpejtë antigjeni) dhe nuk keni marrë një kod Covid pas 4 orësh? \nAtëherë kontaktoni qendrën telefonike të koronavirusit:
     inform_detail_infobox1_title: Nuk keni marrë ende asnjë kod Covid?
     homescreen_isolation_ended_popup_title: A e keni mbaruar periudhën tuaj të izolimit?
     homescreen_isolation_ended_popup_text: Gjurmimi mund të riaktivizohet sapo të keni mbaruar periudhën e izolimit.
@@ -476,4 +476,19 @@ sq:
     stats_covidcodes_total_header: Total
     stats_covidcodes_0to2days_header: Aktual
     stats_cases_rel_prev_week_popup_header: Ndryshimi me javën e mëparshme
+    meldungen_positive_tested_faq2_title: Kush njoftohet?
+    meldungen_positive_tested_faq2_text: Të gjithë kontaktet në periudhën e fazës tuaj të infektimit nga {ONSET_DATE} deri në hyrjen e kodit Covid njoftohen nëse ekziston mundësia e infektimit për shkak të distancës dhe kohëzgjatjes.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – sot
+    inform_send_thankyou_text_stop_infection_chains: Duke vepruar kështu, ju ndihmoni të ndaloni zinxhirin e infektimit.
+    inform_send_thankyou_text_onsetdate_info: Çelësat privatë të aplikacionit tuaj janë dërguar për periudhën kohore vijuese:
+    android_inform_tracing_enabled_explanation: Kur futni një kod Covid, gjurmimi duhet të aktivizohet në mënyrë që çelësat tuaj privatë të mund të shpërndahen.
+    leitfaden_infopopup_text: Nëse shtypni "{BUTTON_TITLE}", dilni nga aplikacioni dhe kaloni në faqen e internetit të udhëzuesit SwissCovid. Të dhënat e takimeve të fundit të infektimeve të mundshme dërgohen gjithashtu në faqen e internetit.
+    leitfaden_infopopup_title: Informacion për udhëzuesin SwissCovid
+    germany_update_boarding_title: E pajtueshme me Gjermaninë
+    germany_update_boarding_text: Ju gjithashtu informoheni nëse keni qenë në kontakt me një person që përdor aplikacionin gjerman Corona-Warn-App dhe më vonë keni rezultuar pozitiv dhe anasjelltas. Për këtë qëllim, kushtet e përdorimit dhe deklarata për mbrojtjen e të dhënave janë aktualizuar.
+    germany_update_boarding_heading: Aktualizimi i SwissCovid
     reset_update_boarding: Rivendos update boarding
+    meldungen_detail_free_test_text: Një test i koronavirusit është i dobishëm dhe rekomandohet që nga dita e 5-të pas datës së treguar të kontaktit.
+    meldungen_detail_free_test_in_x_tagen: Në {COUNT} ditë
+    meldungen_detail_free_test_now: Tani
+    meldungen_detail_free_test_tomorrow: Në 1 ditë

--- a/dpppt-config-backend/src/main/resources/i18n/messages_sq.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_sq.properties
@@ -300,7 +300,7 @@ sq:
     accessibility_tracing_has_been_activated: Gjurmimi u aktivizua
     accessibility_tracing_has_been_deactivated: Gjurmimi u çaktivizua
     meldungen_detail_free_test_title: Testi pa kosto është i mundur
-    meldungen_detail_free_test_text: Udhëzuesi "SwissCovid" ju informon për mundësinë e një testi falas të koronavirusit.
+    meldungen_detail_free_test_text_old: Udhëzuesi "SwissCovid" ju informon për mundësinë e një testi falas të koronavirusit.
     activate_tracing_button: Aktivizo gjurmimin
     tracing_turned_off_detailed_text: Aktivizoni gjurmimin, në mënyrë që të ruhen përdorimet e aplikacionit dhe të merren njoftimet.
     meldungen_tracing_not_active_warning: Nëse gjurmimi është i çaktivizuar, atëherë nuk mund të merret asnjë njoftim.
@@ -476,3 +476,4 @@ sq:
     stats_covidcodes_total_header: Total
     stats_covidcodes_0to2days_header: Aktual
     stats_cases_rel_prev_week_popup_header: Ndryshimi me javën e mëparshme
+    reset_update_boarding: Rivendos update boarding

--- a/dpppt-config-backend/src/main/resources/i18n/messages_sr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_sr.properties
@@ -300,7 +300,7 @@ sr:
     accessibility_tracing_has_been_activated: Praćenje je aktivirano
     accessibility_tracing_has_been_deactivated: Praćenje je deaktivirano
     meldungen_detail_free_test_title: Moguće je besplatno testiranje
-    meldungen_detail_free_test_text: SwissCovid smernice informišu Vas o mogućnosti besplatnog testiranja na virus korona.
+    meldungen_detail_free_test_text_old: SwissCovid smernice informišu Vas o mogućnosti besplatnog testiranja na virus korona.
     activate_tracing_button: Aktiviraj praćenje
     tracing_turned_off_detailed_text: Aktivirajte praćenje kako bi aplikacija mogla da čuva kontakte i prima poruke.
     meldungen_tracing_not_active_warning: Ako je praćenje deaktivirano, ni primanje poruka neće biti moguće.
@@ -475,3 +475,4 @@ sr:
     stats_covidcodes_total_header: Ukupno
     stats_covidcodes_0to2days_header: Aktuelno
     stats_cases_rel_prev_week_popup_header: Promena u vezi prošle nedelje
+    reset_update_boarding: Resetuj update boarding

--- a/dpppt-config-backend/src/main/resources/i18n/messages_sr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_sr.properties
@@ -209,7 +209,7 @@ sr:
     no_meldungen_box_link: Evo kako da se zaštitimo
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Šta je Covid šifra?
-    inform_detail_faq1_text: Ljudi koji su testirani pozitivno na virus korona dobijaju Covid šifru.\n\nTime se osigurava da se putem aplikacije prijavljuju samo potvrđeni slučajevi.
+    inform_detail_faq1_text: Osobe pozitivno testirane na korona virus (PCR test ili antigen (brzi test) dobijaju kovid šifru.\n\nTime se obezbeđuje da samo potvrđeni slučajevi budu prijavljeni preko aplikacije.
     inform_detail_faq2_title: Šta se šalje?
     inform_detail_faq2_text: Šalju se samo privatni identifikacioni ključevi iz vaše aplikacije, a ne šalju se lični podaci.\n\nTime drugi korisnici aplikacije SwissCovid mogu da saznaju da postoji mogućnost infekcije.
     infoline_tel_number: +41 58 387 77 78
@@ -463,7 +463,7 @@ sr:
     stats_cases_rel_prev_week_description: Pokazuje promenu proseka od 7 dana upoređujući stanje od pre nedelju dana.
     stats_cases_current_label: Aktuelan razvoj
     stats_cases_current_description: Grafika pokazuje prijavljene nove infekcije poslednjih 28 dana. Time imate pregled o aktuelnom razvoju.
-    inform_detail_infobox1_text: Testirani ste pozitivno i 4 h posle još niste dobili Covid šifru?\nKontaktirajte info-liniju za Covid šifre:
+    inform_detail_infobox1_text: Pozitivno ste testirani (PCR test ili antigen brzi test) i ni posle 4 sata niste dobili kovid šifru?\nU tom slučaju kontaktirajte Infoline Coronavirus:
     inform_detail_infobox1_title: Još niste dobili Covid šifru?
     homescreen_isolation_ended_popup_title: Da li je vaša izolacija istekla?
     homescreen_isolation_ended_popup_text: Praćenje može opet da se aktivira, čim ste završili sa izolacijom.
@@ -475,4 +475,19 @@ sr:
     stats_covidcodes_total_header: Ukupno
     stats_covidcodes_0to2days_header: Aktuelno
     stats_cases_rel_prev_week_popup_header: Promena u vezi prošle nedelje
+    meldungen_positive_tested_faq2_title: Ko se obaveštava
+    meldungen_positive_tested_faq2_text: Obaveštavaju se svi kontakti u periodu vaše faze zaražavanja od {ONSET_DATE} do unosa kovid šifre, ukoliko je na osnovu distance i trajanja postojala mogućnost zaraze.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – danas
+    inform_send_thankyou_text_stop_infection_chains: Na taj način pomažete u zaustavljanju lanca zaraze.
+    inform_send_thankyou_text_onsetdate_info: Privatni ključevi vaše aplikacije poslati su za sledeći period:
+    android_inform_tracing_enabled_explanation: Prilikom unosa kovid šifre mora se aktivirati praćenje (tracing) kako bi vaši privatni ključevi mogli da se dele.
+    leitfaden_infopopup_text: Kada pritisnete "{BUTTON_TITLE}" napuštate aplikaciju i dolazite na internet stranicu SwissCovid vodiča. Pri tome se podaci poslednjeg susreta sa mogućim zaražavanjem šalju internet stranici.
+    leitfaden_infopopup_title: Informacije iz SwissCovid vodiča
+    germany_update_boarding_title: Kompatibilno sa Nemačkom
+    germany_update_boarding_text: Takođe ćete biti informisani ako ste bili u kontaktu sa osobom koja koristi nemačku aplikaciju na upozorenje na koronu i kasnije je testirana pozitivno i obrnuto. U tu svrhu su ažurirani uslovi korišćenja i izjava o zaštiti podataka.
+    germany_update_boarding_heading: SwissCovid ažuriranje
     reset_update_boarding: Resetuj update boarding
+    meldungen_detail_free_test_text: Testiranje na koronu ima smisla i preporučuje se posle 5. dana od prikazanog datuma kontakta.
+    meldungen_detail_free_test_in_x_tagen: Za {COUNT} dana
+    meldungen_detail_free_test_now: Sada
+    meldungen_detail_free_test_tomorrow: Za 1 dan

--- a/dpppt-config-backend/src/main/resources/i18n/messages_ti.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_ti.properties
@@ -300,7 +300,7 @@ ti:
     accessibility_tracing_has_been_activated: ምክትታል ተጀሚሩ (ከም ዝሰርሕ ተጌሩ)
     accessibility_tracing_has_been_deactivated: ምክትታል ተቛሪጹ (ከም ዘይሰርሕ ተጌሩ)
     meldungen_detail_free_test_title: ነጻ መርመራ ይከኣል'ዩ
-    meldungen_detail_free_test_text: መምርሒ SwissCovid ብዛዕባ ኣማራጺ ነጻ ዝኾነ መርመራ ኮሮናቫይረስ ይሕብረኩም።
+    meldungen_detail_free_test_text_old: መምርሒ SwissCovid ብዛዕባ ኣማራጺ ነጻ ዝኾነ መርመራ ኮሮናቫይረስ ይሕብረኩም።
     activate_tracing_button: ንትራይሲንግ(Tracing) ምውላዕ
     tracing_turned_off_detailed_text: ንትራይሲንግ ወልዕዎ፣ እቲ ኤፕ ዝኾነ ርክብ ክዕቅብ ከምኡ'ውን መልእኽትታት ክቕበል መታን ክኽእል።
     meldungen_tracing_not_active_warning: ትራይሲንግ እንተዘይተወሊዑ መልእኽትታት ውን ክኣትዉ ኣይክእሉን።

--- a/dpppt-config-backend/src/main/resources/i18n/messages_ti.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_ti.properties
@@ -209,7 +209,7 @@ ti:
     no_meldungen_box_link: ብኸምዚ መንገዲ ንነብስና ንከላኸል
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: ኮቪድኮድ እንታይ እዩ፧
-    inform_detail_faq1_text: ውጽኢት መርመርኦም ፖዚቲቭ ዝኾኑ ሰባት ኮቪድኮድ ይውሃቦም። ብኸምዚ መንገዲ እቶም ሕማም ዝተረጋገጸሎም ሰባት ጥራይ በቲ ኣፕ ከምዝምዝገቡ ይረጋገጽ። 
+    inform_detail_faq1_text: ሰባት ኮሮናቫይረስ ከምዘለዎም ምስዝረጋግጽ / ፖዚቲቭ ምስኮኑ (ናይ PCR መርመራ ወይ ቅልጡፍ መርመራ ጸረ-ፈርዒ) ሓደ ኮቪድ-ኮድ ክወሃቡ እዮም።\n\nሽዑ ጥራይ ዝተረጋገጹ ጉዳያት በቲ ኤፕ ክሕበሩ ከምዝኾኑ ተረጋጊጹ።
     inform_detail_faq2_title: እንታይ እዩ ዝስደድ፧ 
     inform_detail_faq2_text: ውልቃዊ ሓበሬታ ዘይኮነ፣ ጥራይ እቶም ግላውያን መፋትሕ እዮም ዝስደዱ።\n  \nብኸምዚ መንገዲ ካልኦት ተጠቀምቲ ስዊስኮቪድ ተኽእሎ መልከፍቲ ሕማም ከምዘሎ ይፈልጡ።
     infoline_tel_number: +41 58 387 77 78
@@ -464,7 +464,7 @@ ti:
     stats_cases_rel_prev_week_description: ንቅያር ገምጋም 7 መዓልቲ የርኢ ምስቲ ናይ ቅድሚ ሓደ ሰሙን እንተትነጻጸር ኮይንካ።
     stats_cases_current_label: ግዝያዊ ምዕባለ
     stats_cases_current_description: እቲ ስእሊ ነቶም ዝተሓበሩ ሓድሽቲ ልበዳታት ኣብ ዝሓለፉ 28 መዓልትታት የርኢ። እዚ ሓፈሻዊ ሓበሬታ ብዛዕባ ግዝያዊ ምዕባለ ይህብ።
-    inform_detail_infobox1_text: ኣወንታዊ ኮቪድ ኣባኹም ተረጋጊጹ፣ ድሕሪ 4 ሰዓት ናይ ኮቪድ ኮድ ገና ኣይተወሃብኩምን፧\nሽዑ ናይ ኮቪድ-ኮድ ሓበሬታ ስልኪ ርኸቡ፥
+    inform_detail_infobox1_text: ፖዚቲቭ ተመርሚርኩም (ናይ PCR መርመራ ወይ ቅልጡፍ መርመራ ጸረ-ፈርዒ) ከምኡ'ውን ድሕሪ 4 ሰዓት ገና ናይ ኮቪድ ኮድ ኣይተወሃብኩምን፧ ሽዑ እቲ ኢንፎላይን ኮሮናቫይረስ ርኸቡ ኢኹም፥
     inform_detail_infobox1_title: ናይ ኮቪድ ኮድ ገና የብልኩምን፧
     homescreen_isolation_ended_popup_title: ግለላኹም ውዲእኹሞ ዶ፧
     homescreen_isolation_ended_popup_text: ነቲ ግለላ ወዲእኹሞ እንተኾይንኩም እቲ ምክትታል መሊሱ ክውላዕ ይከኣል።
@@ -476,3 +476,18 @@ ti:
     stats_covidcodes_total_header: ጥቕላላ
     stats_covidcodes_0to2days_header: ሓድሽ ሓበሬታ
     stats_cases_rel_prev_week_popup_header: ቅያር ካብ ዝሓለፈ ሰሙን
+    meldungen_positive_tested_faq2_title: መን ክሕበር እዩ፧
+    meldungen_positive_tested_faq2_text: ኩሎም ኣብ እዋንኩም መልከፍቲ ካብ {ONSET_DATE} ክሳብ ምእታው ኮቪድ-ኮድ ዝነበረኩም ርክባት ክሕበሩ እዮም፣ ብምኽንያት ርሕቐትን እዋንን ኣማራጺ ልበዳ እንድሕር ኔሩ።
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – ሎሚ
+    inform_send_thankyou_text_stop_infection_chains: ሽዑ ናይ ልበዳ ሰንሰለታት ንክቋረጹ ትሐባበሩ ኢኹም።
+    inform_send_thankyou_text_onsetdate_info: ግላውያን መፋትሕ ናይ ኤፕኩም ንዝስዕብ እዋን ተሰዲዶም ኔሮም፥
+    android_inform_tracing_enabled_explanation: ኣብ ምእታው ኮቪድ-ኮድ እቲ ምክትታል ክውላዕ ኣለዎ፣ ግላዊ መፍትሕኩም ክካፈል መታን ክከኣል።
+    leitfaden_infopopup_text: መጠወቒ "{BUTTON_TITLE}" ትጥውቕዎ እንተኾይንኩም፣ ካብቲ ኤፕ ትወጽኡ ከምኡ'ውን ናብቲ መርበብ ኢንተርነት መምርሒ SwissCovid ክትቕይሩ። ሽዑ ሓበሬታ/ዳታ ናይ ተፈጺሞም ዝኾኑ ልበዳታት ናይቲ ዝሓለፈ ምርኽኻብ ካብቲ መርበብ ኢንተርነት እንተላይ ይስደዱ።
+    leitfaden_infopopup_title: ሓበሬታ መምርሒ SwissCovid
+    germany_update_boarding_title: ምስ ጀርመን ዝሰማማዕ 
+    germany_update_boarding_text: ዋላ ምስ ናይ መጠንቀቕታ ኮሮና ኤፕ ዝጥቐምን ድሓር ፖዚቲቭ ዝተመርመረን ሰብ ምርኽኻብ እንተነበረኩም ንስኹም ዋላ ክትሕበሩ ኢኹም። ሽዑ እቶም ናይ ኣጠቓቕማ ኩነታት ከምኡ'ውን ስምምዕ ምክልኻል ዳታ ክሕደሱ እዮም።
+    germany_update_boarding_heading: ምምሕዳስ SwissCovid
+    meldungen_detail_free_test_text: መርመራ ኮሮና ካብ 5ይ መዓልቲ ድሕሪ ዝተረኣየ ዕለት ርክብ ጠቓሚ እዩ ከምኡ'ውን ክግበር ይመርጽ።
+    meldungen_detail_free_test_in_x_tagen: ኣብ {COUNT} መዓልትታት
+    meldungen_detail_free_test_now: ሕጂ
+    meldungen_detail_free_test_tomorrow: ኣብ 1 መዓልቲ

--- a/dpppt-config-backend/src/main/resources/i18n/messages_tr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_tr.properties
@@ -300,7 +300,7 @@ tr:
     accessibility_tracing_has_been_activated: Takip etkinleştirilmiştir
     accessibility_tracing_has_been_deactivated: Takip devre dışı bırakılmıştır
     meldungen_detail_free_test_title: Ücretsiz test olma
-    meldungen_detail_free_test_text: SwissCovid Kılavuzu, ücretsiz Corona virüs testi imkanları hakkında sizi bilgilendirecektir.
+    meldungen_detail_free_test_text_old: SwissCovid Kılavuzu, ücretsiz Corona virüs testi imkanları hakkında sizi bilgilendirecektir.
     activate_tracing_button: Takibi etkinleştir
     tracing_turned_off_detailed_text: Uygulamanın temasları kaydedebilmesi ve bildirimleri alabilmesi için takibi etkinleştirin.
     meldungen_tracing_not_active_warning: Takip devre dışı bırkıldığında bildirimler de alınamaz.

--- a/dpppt-config-backend/src/main/resources/i18n/messages_tr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_tr.properties
@@ -209,7 +209,7 @@ tr:
     no_meldungen_box_link: Kendimizi bu şekilde koruruz
     no_meldungen_box_url: https://www.bag-coronavirus.ch
     inform_detail_faq1_title: Bir Kovid kodu nedir?
-    inform_detail_faq1_text: Korona virüsü testi pozitif olan kişilere Kovid kodu verilir.\n\nBu şekilde yalnızca onaylanmış vakaların uygulama üzerinden bildirilmesi garantilenir.
+    inform_detail_faq1_text: Koronavirüs için testi pozitif çıkan kişiler (PCR testi veya hızlı antijen testi) bir Covid kodu alır.\n\nBöylece uygulama üzerinden yalnızca onaylı vakaların bildirilmesi sağlanır.
     inform_detail_faq2_title: Neler iletilir?
     inform_detail_faq2_text: Şahsi bilgileriniz değil, uygulamanızın yalnızca özel kodları iletilir. \nBu şekilde diğer SwissCovid uygulaması kullanıcıları yalnızca bir bulaşma riski olabileceğini öğenir.
     infoline_tel_number: +41 58 387 77 78
@@ -465,7 +465,7 @@ tr:
     stats_cases_rel_prev_week_description: Bir hafta öncesinin durumuna nazaran 7 günlük ortalamanın değişimini gösterir.
     stats_cases_current_label: Güncel gelişme
     stats_cases_current_description: Grafik son 28 günde bildirilmiş olan yeni enfeksiyonları gösterir. Bu ise güncel gelişme hakkında genel bir bakış kazandırır.
-    inform_detail_infobox1_text: Test sonucunuz pozitif çıktı ve 4 saat içerisinde henüz Covid kodunu almadınız mı? \nBu durumda, Covid Kodu Bilgi Hattı (Infoline) ile iletişime geçiniz:
+    inform_detail_infobox1_text: Testiniz pozitif çıktı (PCR testi veya hızlı antijen testi) ve 4 saat sonra halen bir Covid kodu almadınız mı?\nO halde koronavirüz danışma hattıyla iletişim kurun:
     inform_detail_infobox1_title: Covid kodunu henüz almadınız mı?
     homescreen_isolation_ended_popup_title: İzolasyonunuzu sonlandırdınız mı?
     homescreen_isolation_ended_popup_text: İzolasyonu sonlandırdığınız anda izleme tekrar etkin hale getirilebilir.
@@ -477,3 +477,18 @@ tr:
     stats_covidcodes_total_header: Toplam
     stats_covidcodes_0to2days_header: Güncel
     stats_cases_rel_prev_week_popup_header: Önceki haftaya göre değişim
+    meldungen_positive_tested_faq2_title: Kimlere haber verilir?
+    meldungen_positive_tested_faq2_text: Mesafe ve süre nedeniyle bir bulaşma olasılığı mevcut ise {ONSET_DATE} gününden başlamak üzere, Covid kodunuzun girilmesine kadar, bulaşma döneminizin aralığındaki tüm temaslılara haber verilir.
+    inform_send_thankyou_text_onsetdate: {ONSET_DATE} – bugün
+    inform_send_thankyou_text_stop_infection_chains: Bu sayede enfeksiyon zincirlerinin durdurulması için yardımcı olacaksınız.
+    inform_send_thankyou_text_onsetdate_info: Uygulamanızın özel anahtarları şu zaman aralığı için gönderildi:
+    android_inform_tracing_enabled_explanation: Bir Covid kodu girerken, özel anahtarlarınızın paylaşılabilmesi için izleme etkinleştirilmiş olmalıdır.
+    leitfaden_infopopup_text: "{BUTTON_TITLE}" üzerine basarsanız, uygulamadan çıkıp SwissCovid rehberinin web sitesine gidersiniz. Bu esnada olası bulaşmalara ait son karşılaşmaların verileri de web sitesine gönderilir.
+    leitfaden_infopopup_title: SwissCovid rehberi bilgisi
+    germany_update_boarding_title: Almanya ile uyumlu
+    germany_update_boarding_text: Almanya'nın korona uyarı uygulamasını kullanan ve sonradan testi pozitif çıkan bir kişiyle temas ettiğinizde ve bunun tersi durumunda da bilgilendirilirsiniz. Bunun için kullanım koşulları ve veri koruma beyanı güncellenmiştir.
+    germany_update_boarding_heading: SwissCovid Güncellemesi 
+    meldungen_detail_free_test_text: Gösterilen temas tarihinden sonraki 5. gün itibariyle bir korona testi yapılması uygundur ve tavsiye edilir.
+    meldungen_detail_free_test_in_x_tagen: {COUNT} gün sonra
+    meldungen_detail_free_test_now: Şimdi
+    meldungen_detail_free_test_tomorrow: 1 gün sonra


### PR DESCRIPTION
Update translations to make it clear, that a positive PCR-Test or Antigen-Schnelltest ist necessary to received a CovidCode.