### PR TITLE
Fix infobox key for Tr and Ti

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/GaenConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/GaenConfigController.java
@@ -394,8 +394,8 @@ public class GaenConfigController {
 		collection.setBsInfoBox(infoBoxbs);
 		collection.setRmInfoBox(infoBoxrm);
 		collection.setSrInfoBox(infoBoxsr);
-		collection.setTiInfobox(infoBoxti);
-		collection.setTrInfobox(infoBoxtr);
+		collection.setTiInfoBox(infoBoxti);
+		collection.setTrInfoBox(infoBoxtr);
 
 		configResponse.setInfoBox(collection);
 

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/helper/IOS136InfoBoxHelper.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/helper/IOS136InfoBoxHelper.java
@@ -119,7 +119,7 @@ public class IOS136InfoBoxHelper {
 		infoBoxRm.setIsDismissible(true);
 
 		InfoBox infoBoxTr = new InfoBox();
-		infoBoxCollection.setTrInfobox(infoBoxTr);
+		infoBoxCollection.setTrInfoBox(infoBoxTr);
 		infoBoxTr.setMsg(
 				"Cep telefonunuzun işletim sistemi, tespit edilen temaslı kişilerin sayısı hakkında haftalık güncelleme ile sizi bilgilendirir. Dilerseniz bu bildirimleri engelleyebilirsiniz. iOS 13.7 sürümünden itibaren bu bilgi artık görüntülenmemektedir; telefonunuzu güncellemenizi tavsiye ediyoruz.\n"
 						+ "\n"
@@ -131,7 +131,7 @@ public class IOS136InfoBoxHelper {
 		infoBoxTr.setIsDismissible(true);
 
 		InfoBox infoBoxTi = new InfoBox();
-		infoBoxCollection.setTiInfobox(infoBoxTi);
+		infoBoxCollection.setTiInfoBox(infoBoxTi);
 		infoBoxTi.setMsg(
 				"እቲ ስርዓተ መስርሕ ኣብ ሞባይልኩም ኩሉ ሰሙን ምስቲ ዝመጽእ ኣፕደይት ብዛዕባ መጠን ዝተረጋገጸ ምንቅስቓስ ይሕብረኩም። እዚ ምልክት ከተስተውዕሉ ኣየድልየኩምን። ካብ ቨርዝዮን iOS 13.7 ንየው እዚ ሓበሬታ ኣይክረአን እዩ፤ ሞባይላትኩም ከተሕድስዎም ንመኽረኩም ኢና።\n"
 						+ "\n"

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/helper/MockHelper.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/helper/MockHelper.java
@@ -130,8 +130,8 @@ public class MockHelper {
 		collection.setBsInfoBox(infoBoxbs);
 		collection.setRmInfoBox(infoBoxrm);
 		collection.setSrInfoBox(infoBoxsr);
-		collection.setTrInfobox(infoBoxtr);
-		collection.setTiInfobox(infoBoxti);
+		collection.setTrInfoBox(infoBoxtr);
+		collection.setTiInfoBox(infoBoxti);
 
 		configResponse.setInfoBox(collection);
 

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBoxCollection.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/InfoBoxCollection.java
@@ -28,8 +28,8 @@ public class InfoBoxCollection {
 	private InfoBox hrInfoBox;
 	private InfoBox srInfoBox;
 	private InfoBox rmInfoBox;
-	private InfoBox trInfobox;
-	private InfoBox tiInfobox;
+	private InfoBox trInfoBox;
+	private InfoBox tiInfoBox;
 
 	public InfoBox getPtInfoBox() {
 		return this.ptInfoBox;
@@ -119,19 +119,19 @@ public class InfoBoxCollection {
 		this.deInfoBox = deInfoBox;
 	}
 
-	public InfoBox getTrInfobox() {
-		return trInfobox;
+	public InfoBox getTrInfoBox() {
+		return trInfoBox;
 	}
 
-	public void setTrInfobox(InfoBox trInfobox) {
-		this.trInfobox = trInfobox;
+	public void setTrInfoBox(InfoBox trInfoBox) {
+		this.trInfoBox = trInfoBox;
 	}
 
-	public InfoBox getTiInfobox() {
-		return tiInfobox;
+	public InfoBox getTiInfoBox() {
+		return tiInfoBox;
 	}
 
-	public void setTiInfobox(InfoBox tiInfobox) {
-		this.tiInfobox = tiInfobox;
+	public void setTiInfoBox(InfoBox tiInfoBox) {
+		this.tiInfoBox = tiInfoBox;
 	}
 }


### PR DESCRIPTION
The infobox key for Tr and Ti was erroneously set as `*infobox` compared to the correct version `*infoBox`. Notice the captialization of `box` in `infoBox`. 

To be consistend field names and setters were updated as well as the crucial getter (used by Jackson to guess the property name). 